### PR TITLE
13 signal detection and plot cleanup

### DIFF
--- a/docs/files/config.json
+++ b/docs/files/config.json
@@ -48,13 +48,13 @@
     "theta": 0,
     "delta_theta": 5,
     "plot_figsize": [
-        80,
-        40
+        30,
+        10
     ],
     "plot_dpi": 300,
     "iq_threshold_factor": 0.4,
     "cusum_offset": 5,
     "cusum_threshold": 1000,
-    "t_fit_begin": 20,
-    "t_fit_end": 300
+    "t_fit_begin": 20e-9,
+    "t_fit_end": 300e-9
 }

--- a/docs/files/config.json
+++ b/docs/files/config.json
@@ -53,7 +53,7 @@
     ],
     "plot_dpi": 300,
     "iq_threshold_factor": 0.4,
-    "cusum_offset": 5,
+    "cusum_offset": 1,
     "cusum_threshold": 1000,
     "t_fit_begin": 20e-9,
     "t_fit_end": 300e-9

--- a/src/alpss/alpss_main.py
+++ b/src/alpss/alpss_main.py
@@ -10,7 +10,7 @@ from alpss.analysis.spall import spall_analysis
 from alpss.analysis.full_uncertainty import full_uncertainty_analysis
 from alpss.analysis.instantaneous_uncertainty import instantaneous_uncertainty_analysis
 from alpss.analysis.hel import hel_detection
-from alpss.utils import extract_data
+from alpss.utils import extract_data, display_figure, open_file_for_display
 from alpss.io.saving import save
 from datetime import datetime
 import traceback
@@ -132,8 +132,9 @@ def alpss_main(**inputs):
             logger.info("Attempting a fallback visualization of the voltage signal...")
             plot_voltage(data, **inputs)
             logger.info("Fallback voltage plot saved.")
-        except Exception:
-            logger.error("Fallback visualization also failed.")
+        except Exception as fe:
+            logger.error("Fallback visualization also failed: %s", str(fe))
+            logger.error("Fallback traceback: %s", traceback.format_exc())
         # Re-raise so the caller can track this as a failure
         raise
 
@@ -287,9 +288,8 @@ def alpss_main(**inputs):
         filename = os.path.splitext(os.path.basename(inputs["filepath"]))[0]
         fig_path = os.path.abspath(os.path.join(inputs["out_files_dir"], f"{filename}-plots.png"))
         if os.path.exists(fig_path):
-            os.startfile(fig_path)
+            open_file_for_display(fig_path)
         else:
-            import matplotlib.pyplot as plt
-            plt.show()
+            display_figure(fig)
 
     return (fig, items)

--- a/src/alpss/alpss_main.py
+++ b/src/alpss/alpss_main.py
@@ -283,4 +283,13 @@ def alpss_main(**inputs):
 
     logger.info("Outputs saved")
 
+    if inputs.get("display_plots") == "yes":
+        filename = os.path.splitext(os.path.basename(inputs["filepath"]))[0]
+        fig_path = os.path.abspath(os.path.join(inputs["out_files_dir"], f"{filename}-plots.png"))
+        if os.path.exists(fig_path):
+            os.startfile(fig_path)
+        else:
+            import matplotlib.pyplot as plt
+            plt.show()
+
     return (fig, items)

--- a/src/alpss/carrier/filter.py
+++ b/src/alpss/carrier/filter.py
@@ -45,6 +45,7 @@ def carrier_filter(sdf_out, cen, **inputs):
         sin_fit = 'none'
         display_freq = 'none'
         display_vals = 'none'
+        display_vals_filtered = 'none'
 
     elif inputs["carrier_filter_type"] == 'sin_fit_subtract':
         t_fit_begin = inputs["t_fit_begin"]
@@ -98,7 +99,11 @@ def carrier_filter(sdf_out, cen, **inputs):
 
         # prepare the fft freqs and vals for plotting
         display_vals = fft_vals[freq>0]
+        display_vals_filtered = fft_vals[mask_sin_fit]
         display_freq = freq[freq>0]
+        
+        fft_vals_filtered = fft(voltage_filt[carrier_analysis_time_mask])
+        display_vals_filtered = fft_vals_filtered[freq>0]
     elif inputs["carrier_filter_type"] == 'none': 
         voltage_filt = voltage
         time_fitting = 'none'
@@ -106,6 +111,7 @@ def carrier_filter(sdf_out, cen, **inputs):
         sin_fit = 'none'
         display_freq = 'none'
         display_vals = 'none'
+        display_vals_filtered = 'none'
     else:
         raise ValueError(f'Invalid carrier filter type: {inputs["carrier_filter_type"]}')
 
@@ -126,6 +132,12 @@ def carrier_filter(sdf_out, cen, **inputs):
     # save outputs to a dictionary
     cf_out = {
         "voltage_filt": voltage_filt,
+        "time_fitting": time_fitting,
+        "carrier_fitting": time_domain_carrier,
+        "sin_fitting": sin_fit,
+        "freq": display_freq,
+        "fft_vals": display_vals,
+        "fft_vals_filtered": display_vals_filtered,
         "f_filt": f_filt,
         "t_filt": t_filt,
         "Zxx_filt": Zxx_filt,

--- a/src/alpss/detection/spall_doi_finder.py
+++ b/src/alpss/detection/spall_doi_finder.py
@@ -120,6 +120,7 @@ def spall_doi_finder(data, **inputs):
             # these params are only needed if finding start time using cusum
             signal = np.nan
             s = np.nan
+            time_eval = np.nan
         elif inputs.get('start_time_user') == "iq":
             t_start_detected_iq, amplitude, phase, iq_fig = iq_analysis(inputs, voltage, fs, time)
 
@@ -130,7 +131,8 @@ def spall_doi_finder(data, **inputs):
             # these params are only needed if using cusum
             signal = np.nan
             s = np.nan
-            
+            time_eval = np.nan
+
             t_start_detected = t_start_detected_iq
         elif inputs["start_time_user"]=="cusum": 
 
@@ -143,26 +145,33 @@ def spall_doi_finder(data, **inputs):
 
             # Apply a bandpass filter to get rid of noise outside of frequency bounds
             numpts = len(time)
-            freq = fftshift(np.arange((-numpts / 2), (numpts / 2)) * fs / numpts)
-            filt = (freq > f_min) * (freq < f_max)
-            voltage_filt = ifft(fft(voltage) * filt)
+            pad_len = numpts // 2
+            voltage_padded = np.pad(voltage, (pad_len, pad_len), mode='reflect')
+            numpts_padded = len(voltage_padded)
+            freq_padded = fftshift(np.arange((-numpts_padded / 2), (numpts_padded / 2)) * fs / numpts_padded)
+            filt_padded = (freq_padded > f_min) * (freq_padded < f_max)
+            voltage_filt_padded = ifft(fft(voltage_padded) * filt_padded)
+            voltage_filt = voltage_filt_padded[pad_len:pad_len + numpts]
 
             # Unwrap the phase
             phas = np.unwrap(np.angle(voltage_filt), axis=0)
 
             # Analyzed signal is equal to the gradient of the phase. Essentially a pseudo-velocity
-            signal = np.gradient(savgol_filter(phas,inputs["smoothing_window"],3))
+            # signal = np.gradient(savgol_filter(phas,inputs["smoothing_window"],3))
+            signal = np.gradient(phas)
+
+            # Skip leading edge samples to avoid filter artifact spikes
+            edge_skip = 100
+            signal_eval = signal[edge_skip:]
+            time_eval = time[edge_skip:]
 
             # Initial mean and standard deviation of the signal. Utilized in cusum
-            mask = time < carrier_band_time
-            mu0 = np.mean(signal[mask])
-            sigma0 = np.var(signal[mask])
+            mask = time_eval < carrier_band_time
+            mu0 = np.mean(signal_eval[mask])
+            sigma0 = np.var(signal_eval[mask])
 
-            print('signal shape: ', signal.shape)
-            detection_indices, change_indices, G, s = cusum(signal, mu0, sigma0, h, k)
-
-            print("change _indices shape: ", change_indices.shape)
-            detection_time = time[change_indices]
+            detection_indices, change_indices, G, s = cusum(signal_eval, mu0, sigma0, h, k)
+            detection_time = time_eval[change_indices]
 
             # these params become nan because they are only needed if the program
             # is finding the signal start time automatically
@@ -184,6 +193,7 @@ def spall_doi_finder(data, **inputs):
         f_doi_carr_top_idx = np.nan
         signal = np.nan
         s = np.nan
+        time_eval = np.nan
 
         # use the user input signal start time to define the domain of interest
         t_start_detected = t[np.argmin(np.abs(t - inputs["start_time_user"]))]
@@ -220,6 +230,7 @@ def spall_doi_finder(data, **inputs):
         "start_time_user": inputs.get('start_time_user'),
         "cusum_signal": signal,
         "cusum_s": s,
+        "cusum_time": time_eval,
     }
 
     if inputs.get('start_time_user') == "iq":

--- a/src/alpss/detection/spall_doi_finder.py
+++ b/src/alpss/detection/spall_doi_finder.py
@@ -116,12 +116,20 @@ def spall_doi_finder(data, **inputs):
             
             # add in the user correction for the start time
             t_start_detected = t[cidx]
+
+            # these params are only needed if finding start time using cusum
+            signal = np.nan
+            s = np.nan
         elif inputs.get('start_time_user') == "iq":
             t_start_detected_iq, amplitude, phase, iq_fig = iq_analysis(inputs, voltage, fs, time)
 
             carr_idx = np.nan
             f_doi_carr_top_idx = np.nan
             f_doi_top_line_clean = np.nan
+
+            # these params are only needed if using cusum
+            signal = np.nan
+            s = np.nan
             
             t_start_detected = t_start_detected_iq
         elif inputs["start_time_user"]=="cusum": 
@@ -174,6 +182,8 @@ def spall_doi_finder(data, **inputs):
         f_doi_top_line_clean = np.nan
         carr_idx = np.nan
         f_doi_carr_top_idx = np.nan
+        signal = np.nan
+        s = np.nan
 
         # use the user input signal start time to define the domain of interest
         t_start_detected = t[np.argmin(np.abs(t - inputs["start_time_user"]))]
@@ -207,7 +217,9 @@ def spall_doi_finder(data, **inputs):
         "t_doi_start": t_doi_start,
         "t_doi_end": t_doi_end,
         "power_doi": power_doi,
-        "start_time_user": inputs.get('start_time_user')
+        "start_time_user": inputs.get('start_time_user'),
+        "cusum_signal": signal,
+        "cusum_s": s,
     }
 
     if inputs.get('start_time_user') == "iq":
@@ -228,8 +240,7 @@ def cusum(signal, mu0, sigma, h, k):
     """
     # Score for general mean change
     Z = (signal - mu0)/(np.sqrt(sigma))
-    s = -Z - k
-    # s = ((mu1 - mu0) / sigma) * (signal - mu0) - ((mu0**2 - mu1**2) / (2 * sigma))
+    s = Z - k
     G = np.zeros_like(s)
 
     for k in range(1, len(s)):

--- a/src/alpss/detection/spall_doi_finder.py
+++ b/src/alpss/detection/spall_doi_finder.py
@@ -1,11 +1,14 @@
 import numpy as np
+import matplotlib.pyplot as plt
 import cv2 as cv
 from alpss.utils import stft
 import logging
 from scipy import signal
-from scipy.fft import fft, fftfreq
-import matplotlib.pyplot as plt
-import os
+from numpy.fft import fft,fftfreq
+from scipy.fft import ifft
+from scipy.fftpack import fftshift
+from scipy.signal import savgol_filter
+
 
 # function to find the specific domain of interest in the larger signal
 def spall_doi_finder(data, **inputs):
@@ -127,27 +130,31 @@ def spall_doi_finder(data, **inputs):
             carrier_band_time = inputs["carrier_band_time"]
             k=inputs["cusum_offset"]
             h=inputs["cusum_threshold"]
+            f_min = inputs["freq_min"]
+            f_max = inputs["freq_max"]
 
-            # Carrier band Frequency
-            carrier_mask = time < carrier_band_time
-            carrier_fft_vals = fft(voltage[carrier_mask])
-            carrier_fft_freqs = fftfreq(voltage[carrier_mask].size,1/fs)
-            mask3 = carrier_fft_freqs > 0
-            max_idx = np.argmax(np.abs(carrier_fft_vals*mask3))
-            cen = carrier_fft_freqs[max_idx]
-            idx = np.argmin(np.abs(f-cen))
-            signal = mag[idx,:]
-            mask4 = t < carrier_band_time
-            mask5 = t > (t.max()-carrier_band_time)
-            mu0 = np.mean(signal[mask4])
-            mu1 =  0  # Expected post-change signal level
-            sigma0 = np.var(signal[mask4])
+            # Apply a bandpass filter to get rid of noise outside of frequency bounds
+            numpts = len(time)
+            freq = fftshift(np.arange((-numpts / 2), (numpts / 2)) * fs / numpts)
+            filt = (freq > f_min) * (freq < f_max)
+            voltage_filt = ifft(fft(voltage) * filt)
+
+            # Unwrap the phase
+            phas = np.unwrap(np.angle(voltage_filt), axis=0)
+
+            # Analyzed signal is equal to the gradient of the phase. Essentially a pseudo-velocity
+            signal = np.gradient(savgol_filter(phas,inputs["smoothing_window"],3))
+
+            # Initial mean and standard deviation of the signal. Utilized in cusum
+            mask = time < carrier_band_time
+            mu0 = np.mean(signal[mask])
+            sigma0 = np.var(signal[mask])
 
             print('signal shape: ', signal.shape)
-            detection_indices, change_indices, G, s = cusum(signal, mu0, mu1, sigma0, h, k)
+            detection_indices, change_indices, G, s = cusum(signal, mu0, sigma0, h, k)
 
             print("change _indices shape: ", change_indices.shape)
-            detection_time = t[change_indices]
+            detection_time = time[change_indices]
 
             # these params become nan because they are only needed if the program
             # is finding the signal start time automatically
@@ -211,7 +218,7 @@ def spall_doi_finder(data, **inputs):
     return sdf_out
 
 
-def cusum(signal, mu0, mu1, sigma, h, k):
+def cusum(signal, mu0, sigma, h, k):
     """
     Detect a single mean shift from mu0 to mu1 using CUSUM.
     Returns:

--- a/src/alpss/io/saving.py
+++ b/src/alpss/io/saving.py
@@ -31,7 +31,7 @@ def save(
 
     # save the plots
     fig_assets = [fig]
-    if inputs["save_data"]:
+    if inputs["save_data"] == "yes":
         fig_path = f"{fname}-plots.png"
         fig.savefig(
             fname=fig_path,
@@ -45,7 +45,7 @@ def save(
     inputs.pop("bytestring", None)
     inputs_df = pd.DataFrame.from_dict(inputs, orient="index", columns=["Input"])
     inputs_assets = [inputs_df]
-    if inputs["save_data"]:
+    if inputs["save_data"] == "yes":
         inputs_path = f"{fname}-inputs.csv"
         inputs_df.to_csv(inputs_path, index=True, header=False)
         inputs_assets.append(inputs_path)
@@ -53,7 +53,7 @@ def save(
     # save the noisy velocity trace
     velocity_data = np.stack((vc_out["time_f"], vc_out["velocity_f"]), axis=1)
     velocity_assets = [velocity_data]
-    if inputs["save_data"]:
+    if inputs["save_data"] == "yes":
         velocity_path = f"{fname}-velocity.csv"
         np.savetxt(velocity_path, velocity_data, delimiter=",")
         velocity_assets.append(velocity_path)
@@ -63,7 +63,7 @@ def save(
         (vc_out["time_f"], vc_out["velocity_f_smooth"]), axis=1
     )
     smooth_velocity_assets = [velocity_data_smooth]
-    if inputs["save_data"]:
+    if inputs["save_data"] == "yes":
         smooth_velocity_path = f"{fname}-velocity--smooth.csv"
         np.savetxt(
             smooth_velocity_path,
@@ -82,7 +82,7 @@ def save(
         axis=1,
     )
     voltage_assets = [voltage_data]
-    if inputs["save_data"]:
+    if inputs["save_data"] == "yes":
         voltage_path = f"{fname}-voltage.csv"
         np.savetxt(voltage_path, voltage_data, delimiter=",")
         voltage_assets.append(voltage_path)
@@ -90,7 +90,7 @@ def save(
     # save the noise fraction
     noise_data = np.stack((vc_out["time_f"], iua_out["inst_noise"]), axis=1)
     noise_assets = [noise_data]
-    if inputs["save_data"]:
+    if inputs["save_data"] == "yes":
         noise_path = f"{fname}-noisefrac.csv"
         np.savetxt(noise_path, noise_data, delimiter=",")
         noise_assets.append(noise_path)
@@ -98,7 +98,7 @@ def save(
     # save the velocity uncertainty
     vel_uncert_data = np.stack((vc_out["time_f"], iua_out["vel_uncert"]), axis=1)
     vel_uncert_assets = [vel_uncert_data]
-    if inputs["save_data"]:
+    if inputs["save_data"] == "yes":
         vel_uncert_path = f"{fname}-veluncert.csv"
         np.savetxt(
             vel_uncert_path,
@@ -165,7 +165,7 @@ def save(
 
     results_dict = results_df.iloc[0].to_dict()
     results_assets = [results_dict]
-    if inputs["save_data"]:
+    if inputs["save_data"] == "yes":
         results_path = f"{fname}-results.csv"
         results_df.T.to_csv(results_path, header=False)
         results_assets.append(results_path)

--- a/src/alpss/plotting/plots.py
+++ b/src/alpss/plotting/plots.py
@@ -154,6 +154,8 @@ def plot_results(
     #################### plotting the thresholded spectrogram on the ROI to show how the signal start time is found
     if inputs["start_time_user"] == "cusum":
         ax4.plot(sdf_out["time"]*1e9,sdf_out["cusum_s"])
+        ax4.set_title("Cusum Detection")
+        ax4.set_xlabel("Time (ns)")
     else:
         ax4.imshow(
             sdf_out["th3"],
@@ -395,7 +397,7 @@ def plot_results(
         )
 
     # if not np.isnan(sa_out['t_max_comp']) or not np.isnan(sa_out['t_max_ten']) or not np.isnan(sa_out['t_rc']):
-    ax12.legend(loc="upper left", bbox_to_anchor=(1.01, 1), borderaxespad=0, fontsize=6, framealpha=1)
+    ax12.legend(loc="upper left", borderaxespad=0, fontsize=6, framealpha=1)
     ax12.set_xlim(
         [
             -inputs["t_before"] / 1e-9,
@@ -428,7 +430,7 @@ def plot_results(
         "Value": [
             start_time.strftime("%b %d %Y"),
             start_time.strftime("%I:%M %p"),
-            inputs["filepath"],
+            os.path.basename(inputs["filepath"]),
             (end_time - start_time),
             round(iua_out["tau"] * 1e9, 2),
             round(

--- a/src/alpss/plotting/plots.py
+++ b/src/alpss/plotting/plots.py
@@ -25,7 +25,7 @@ def plot_results(
 
     # create the figure and axes
     plt.close("all")
-    fig = plt.figure(figsize=inputs["plot_figsize"], dpi=inputs["plot_dpi"])
+    fig = plt.figure(figsize=inputs["plot_figsize"], dpi=inputs["plot_dpi"], layout="tight")
     ax1 = plt.subplot2grid((3, 5), (0, 0))  # voltage data
     ax2 = plt.subplot2grid((3, 5), (0, 1))  # noise distribution histogram
     ax3 = plt.subplot2grid((3, 5), (1, 0))  # imported voltage spectrogram
@@ -405,10 +405,6 @@ def plot_results(
 
     # fix the layout
     plt.tight_layout()
-
-    # display the plots if desired. if this is turned off the plots will still save
-    if inputs["display_plots"] == "yes":
-        plt.show()
 
     return fig
 

--- a/src/alpss/plotting/plots.py
+++ b/src/alpss/plotting/plots.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 import pandas as pd
 import os
-from alpss.utils import stft
+from alpss.utils import stft, display_figure, open_file_for_display
 import numpy as np
 import random
 import string
@@ -153,7 +153,7 @@ def plot_results(
 
     #################### plotting the thresholded spectrogram on the ROI to show how the signal start time is found
     if inputs["start_time_user"] == "cusum":
-        ax4.plot(sdf_out["time"]*1e9,sdf_out["cusum_s"])
+        ax4.plot(sdf_out["cusum_time"]*1e9,sdf_out["cusum_s"])
         ax4.set_title("Cusum Detection")
         ax4.set_xlabel("Time (ns)")
     else:
@@ -497,14 +497,18 @@ def plot_voltage(data, **inputs):
     fig.suptitle("ERROR: Program Failed", c="r", fontsize=16)
 
     plt.tight_layout()
+    dest = None
     if inputs["save_data"] == "yes":
         fname = os.path.join(
             inputs["out_files_dir"],
             os.path.splitext(os.path.basename(inputs["filepath"]))[0],
         )
         dest = f"{fname}--error_plot.png"
-        fig.savefig(dest)
+        fig.savefig(dest, dpi="figure", format="png", facecolor="w")
     if inputs["display_plots"] == "yes":
-        plt.show()
+        if dest is not None and os.path.exists(dest):
+            open_file_for_display(dest)
+        else:
+            display_figure(fig)
 
-    return fig, {"error": [mag, dest if inputs["save_data"] == "yes" else None]}
+    return fig, {"error": [mag, dest]}

--- a/src/alpss/plotting/plots.py
+++ b/src/alpss/plotting/plots.py
@@ -81,10 +81,41 @@ def plot_results(
     ax1.set_title("Voltage Data")
 
     #################### noise distribution histogram
-    ax2.hist(iua_out["noise"] * 1e3, bins=50, rwidth=0.8)
-    ax2.set_xlabel("Noise (mV)")
-    ax2.set_ylabel("Counts")
-    ax2.set_title("Voltage Noise")
+    if inputs["carrier_filter_type"]=='sin_fit_subtract':
+        mask_window = (cf_out["freq"]>inputs["freq_min"]) & (cf_out["freq"]<inputs["freq_max"])
+        # FFT of the signal post start time
+        ax2.plot(
+            cf_out["freq"][mask_window]*1e-9,
+            np.abs(cf_out["fft_vals"][mask_window])*1e3,
+            label = "Unfiltered Signal",
+            c = 'b')
+        
+        mask_carrier = (cf_out["freq"]>(cen-inputs["wid"]/2)) & (cf_out["freq"]<(cen+inputs["wid"]/2))
+
+        # Isolated carrier band
+        ax2.plot(
+            cf_out["freq"][mask_carrier]*1e-9,
+            np.abs(cf_out["fft_vals"][mask_carrier])*1e3,
+            label = "Carrier Band",
+            c = 'r')
+
+        # FFT of filtered signal post start time 
+        ax2.plot(
+            cf_out["freq"][mask_window]*1e-9,
+            np.abs(cf_out["fft_vals_filtered"][mask_window])*1e3,
+            label = "Filtered Signal",
+            c = 'g')
+        
+        ax2.set_xlabel("Frequency (GHz)")
+        ax2.set_ylabel("Magnitude")
+        ax2.set_xlim([inputs["freq_min"]*1e-9,inputs["freq_max"]*1e-9])
+        ax2.legend(loc="upper right")
+        ax2.set_title("FFT Carrier Band")
+    else: 
+        ax2.hist(iua_out["noise"] * 1e3, bins=50, rwidth=0.8)
+        ax2.set_xlabel("Noise (mV)")
+        ax2.set_ylabel("Counts")
+        ax2.set_title("Voltage Noise")
 
     #################### imported voltage spectrogram and a rectangle to show the ROI
     plt3 = ax3.imshow(
@@ -113,6 +144,7 @@ def plot_results(
         linewidth=0.75,
         linestyle="-",
     )
+    ax3.set_ylim([0,20])
     ax3.add_patch(win)
     ax3.set_xlabel("Time (ns)")
     ax3.set_ylabel("Frequency (GHz)")
@@ -120,29 +152,33 @@ def plot_results(
     ax3.set_title("Spectrogram Original Signal")
 
     #################### plotting the thresholded spectrogram on the ROI to show how the signal start time is found
-    ax4.imshow(
-        sdf_out["th3"],
-        aspect="auto",
-        origin="lower",
-        interpolation="none",
-        extent=[
-            sdf_out["t"][0] / 1e-9,
-            sdf_out["t"][-1] / 1e-9,
-            sdf_out["f_doi"][0] / 1e9,
-            sdf_out["f_doi"][-1] / 1e9,
-        ],
-        cmap=inputs["cmap"],
-    )
+    if inputs["start_time_user"] == "cusum":
+        ax4.plot(sdf_out["time"]*1e9,sdf_out["cusum_s"])
+    else:
+        ax4.imshow(
+            sdf_out["th3"],
+            aspect="auto",
+            origin="lower",
+            interpolation="none",
+            extent=[
+                sdf_out["t"][0] / 1e-9,
+                sdf_out["t"][-1] / 1e-9,
+                sdf_out["f_doi"][0] / 1e9,
+                sdf_out["f_doi"][-1] / 1e9,
+            ],
+            cmap=inputs["cmap"],
+        )
+        ax4.set_title("Thresholded Spectrogram")
+        ax4.set_ylim([inputs["freq_min"] / 1e9, inputs["freq_max"] / 1e9])
+        ax4.set_xlabel("Time (ns)")
+        ax4.set_ylabel("Frequency (GHz)")
+        ax4.minorticks_on()
+        ax4.set_title("Thresholded Spectrogram")
+        ax4.set_xlim([sdf_out["t_doi_start"] / 1e-9, sdf_out["t_doi_end"] / 1e-9])
+    if inputs["start_time_user"] == "otsu":
+        ax4.axhline(sdf_out["f_doi"][sdf_out["f_doi_carr_top_idx"]] / 1e9, c="r")    
     ax4.axvline(sdf_out["t_start_detected"] / 1e-9, ls="--", c="r")
     ax4.axvline(sdf_out["t_start_corrected"] / 1e-9, ls="-", c="r")
-    if inputs["start_time_user"] == "otsu":
-        ax4.axhline(sdf_out["f_doi"][sdf_out["f_doi_carr_top_idx"]] / 1e9, c="r")
-    ax4.set_ylim([inputs["freq_min"] / 1e9, inputs["freq_max"] / 1e9])
-    ax4.set_xlim([sdf_out["t_doi_start"] / 1e-9, sdf_out["t_doi_end"] / 1e-9])
-    ax4.set_xlabel("Time (ns)")
-    ax4.set_ylabel("Frequency (GHz)")
-    ax4.minorticks_on()
-    ax4.set_title("Thresholded Spectrogram")
 
     #################### plotting the spectrogram of the ROI with the start-time line to see how well it lines up
     plt5 = ax5.imshow(
@@ -209,6 +245,19 @@ def plot_results(
         label="Signal Envelope",
         c="tab:red",
     )
+    if inputs["carrier_filter_type"] == "sin_fit_subtract":
+        ax7.plot(
+            cf_out["time_fitting"] / 1e-9, 
+            cf_out["carrier_fitting"] * 1e3, 
+            label="Carrier Band",
+            c='tab:green')
+        ax7.plot(
+            cf_out["time_fitting"] / 1e-9, 
+            cf_out["sin_fitting"] * 1e3, 
+            label="Sin Fit",
+            c='r', 
+            ls='--',
+            alpha=0.5)
     ax7.plot(vc_out["time_f"] / 1e-9, iua_out["env_min_interp"] * 1e3, c="tab:red")
     ax7.set_xlabel("Time (ns)")
     ax7.set_ylabel("Voltage (mV)")

--- a/src/alpss/utils.py
+++ b/src/alpss/utils.py
@@ -1,9 +1,45 @@
 from scipy.signal import ShortTimeFFT
 import numpy as np
 import io
+import os
+import platform
+import subprocess
+import tempfile
+import threading
 import pandas as pd
 import logging
 logger = logging.getLogger("alpss")
+
+
+def _open_and_cleanup(path):
+    system = platform.system()
+    if system == "Windows":
+        subprocess.run(["cmd", "/c", "start", "/wait", "", path], shell=False)
+    elif system == "Darwin":
+        subprocess.run(["open", "-W", path])
+    else:
+        subprocess.run(["xdg-open", path])
+    if os.path.exists(path):
+        os.remove(path)
+
+
+def display_figure(fig):
+    """Save fig to a temp file, open it with the system viewer, then clean up."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+    tmp.close()
+    fig.savefig(tmp.name, dpi="figure", format="png", facecolor="w")
+    threading.Thread(target=_open_and_cleanup, args=(tmp.name,), daemon=False).start()
+
+
+def open_file_for_display(path):
+    """Open an existing file with the system viewer."""
+    system = platform.system()
+    if system == "Windows":
+        subprocess.run(["cmd", "/c", "start", "", os.path.abspath(path)], shell=False)
+    elif system == "Darwin":
+        subprocess.run(["open", os.path.abspath(path)])
+    else:
+        subprocess.run(["xdg-open", os.path.abspath(path)])
 
 
 def extract_data(inputs):


### PR DESCRIPTION
## Summary

### Detection
1.  Fix CUSUM signal detection bug. Wrong array being passed resulting in run error
2. Add edge-skip for fft artifacts, pad voltage before bandpass filtering

### Plotting
1. Impliment "cusum" plot such that the filter may be visualized. This is only plotted if "cusum" is chosen as signal detection type and replaces the default "otsu" detection plot
2. Impliment "sin_fit_subtract" plot. This is only active if this filter type is chosen. It replaces the noise plot.
4. Replace plt.show() and os.startfile. This allows for easier and quicker visualization of results on manual runs than plt.show(). Also, eliminates the bug where plt.show() messes up the figure aspect size.
5. Cross-platform display_figure/open_file_for_display helpers (Windows, macOS, Linux); plots can now display without saving to disk via a temp file that cleans up after the viewer closes

