### PR TITLE
feat: spall DNS qualifier and SpallResult dataclass

### DIFF
--- a/src/alpss/alpss_main.py
+++ b/src/alpss/alpss_main.py
@@ -186,6 +186,7 @@ def alpss_main(**inputs):
             logger.info("Running HEL detection...")
             # Convert velocity time from seconds to nanoseconds for HEL
             time_ns = vc_out["time_f"] / 1e-9
+            hel_method = inputs.get("hel_method", "gradient")
             hel_out = hel_detection(
                 time_ns,
                 vc_out["velocity_f_smooth"],
@@ -198,13 +199,18 @@ def alpss_main(**inputs):
                 density=inputs.get("density", None),
                 acoustic_velocity=inputs.get("C0", None),
                 C_L=inputs.get("C_L", None),
+                method=hel_method,
+                hel_rdp_epsilon=inputs.get("hel_rdp_epsilon", 1.25),
+                hel_slope_drop_ratio=inputs.get("hel_slope_drop_ratio", 0.9),
+                hel_min_plateau_duration=inputs.get("hel_min_plateau_duration", 0.5),
             )
             if hel_out.ok:
                 logger.info(
-                    "HEL detected: strength=%.4f GPa, FSV=%.2f m/s, time=%.2f ns",
+                    "HEL detected: strength=%.4f GPa, FSV=%.2f m/s, time=%.2f ns (method=%s)",
                     hel_out.strength_gpa,
                     hel_out.free_surface_velocity,
                     hel_out.time_detection_ns,
+                    hel_out.method,
                 )
             else:
                 if hel_out.error_message:

--- a/src/alpss/alpss_main.py
+++ b/src/alpss/alpss_main.py
@@ -6,7 +6,7 @@ from alpss.carrier.frequency import carrier_frequency
 from alpss.carrier.filter import carrier_filter
 from alpss.velocity.calculation import velocity_calculation
 from alpss.validation import validate_inputs
-from alpss.analysis.spall import spall_analysis
+from alpss.analysis.spall import spall_analysis, spall_analysis_with_dns, SpallResult
 from alpss.analysis.full_uncertainty import full_uncertainty_analysis
 from alpss.analysis.instantaneous_uncertainty import instantaneous_uncertainty_analysis
 from alpss.analysis.hel import hel_detection
@@ -70,6 +70,11 @@ def _default_hel_output():
     from alpss.analysis.hel import HELResult
 
     return HELResult(ok=False)
+
+
+def _default_spall_result():
+    """Return a failed SpallResult for graceful degradation."""
+    return SpallResult(ok=False, dns_classification="analysis not run")
 
 
 # main function to link together all the sub-functions
@@ -140,16 +145,35 @@ def alpss_main(**inputs):
     # --- Phase 2a: Spall analysis ---
     errors = []
     sa_out = _default_spall_output()
+    spall_result = _default_spall_result()
     spall_ok = False
+    spall_detection_method = inputs.get("spall_detection_method", "max_min")
+    use_dns = inputs.get("spall_calculation", "yes") == "yes"
     try:
-        logger.info("Running spall analysis...")
+        logger.info("Running spall analysis (method=%s)...", spall_detection_method)
         sa_out = spall_analysis(vc_out, iua_out, **inputs)
         spall_ok = True
         logger.info(
-            "Spall analysis complete: spall strength=%.4f, strain rate=%.4e",
+            "Spall analysis complete: spall strength=%.4f Pa, strain rate=%.4e s^-1",
             sa_out["spall_strength_est"],
             sa_out["strain_rate_est"],
         )
+        if use_dns:
+            spall_result = spall_analysis_with_dns(
+                vc_out, iua_out,
+                spall_detection_method=spall_detection_method,
+                rdp_epsilon=inputs.get("spall_rdp_epsilon", 5.0),
+                min_pullback_velocity=inputs.get("min_pullback_velocity", 10.0),
+                min_recomp_ratio=inputs.get("min_recomp_ratio", 0.03),
+                min_recomp_velocity_ratio=inputs.get("min_recomp_velocity_ratio", 1.10),
+                min_recomp_time_ns=inputs.get("min_recomp_time_ns", 2.5),
+                **inputs,
+            )
+            logger.info(
+                "DNS classification: %s (ok=%s)",
+                spall_result.dns_classification,
+                spall_result.ok,
+            )
     except Exception as e:
         errors.append(f"spall: {e}")
         logger.error("Error in spall analysis: %s", str(e))
@@ -284,6 +308,7 @@ def alpss_main(**inputs):
         spall_ok=spall_ok,
         uncertainty_ok=uncertainty_ok,
         error_msg="; ".join(errors) if errors else "",
+        spall_result=spall_result,
         **inputs,
     )
 

--- a/src/alpss/analysis/__init__.py
+++ b/src/alpss/analysis/__init__.py
@@ -1,4 +1,9 @@
 from alpss.analysis.spall import spall_analysis
 from alpss.analysis.instantaneous_uncertainty import instantaneous_uncertainty_analysis
 from alpss.analysis.full_uncertainty import full_uncertainty_analysis
-from alpss.analysis.hel import hel_detection, elastic_shock_strain_rate, HELResult
+from alpss.analysis.hel import (
+    hel_detection,
+    hel_detection_rdp_hybrid,
+    elastic_shock_strain_rate,
+    HELResult,
+)

--- a/src/alpss/analysis/__init__.py
+++ b/src/alpss/analysis/__init__.py
@@ -1,4 +1,10 @@
-from alpss.analysis.spall import spall_analysis
+from alpss.analysis.spall import (
+    spall_analysis,
+    spall_analysis_with_dns,
+    SpallResult,
+    _detect_spall_topology,
+    _rdp_simplify,
+)
 from alpss.analysis.instantaneous_uncertainty import instantaneous_uncertainty_analysis
 from alpss.analysis.full_uncertainty import full_uncertainty_analysis
 from alpss.analysis.hel import (

--- a/src/alpss/analysis/hel.py
+++ b/src/alpss/analysis/hel.py
@@ -1,8 +1,27 @@
+"""HEL (Hugoniot Elastic Limit) detection for PDV velocity traces.
+
+Two detection methods are available:
+
+* **Gradient / angle-based** (original, :func:`hel_detection`):
+    Smoothed gradient converted to angles; first consecutive low-slope
+    segment is taken as the HEL plateau.  Selected by ``method="gradient"``.
+
+* **RDP + Linear Hybrid** (new, matches HELIX Toolbox v2):
+    Ramer–Douglas–Peucker simplification to find candidate "knee" points,
+    followed by linear regression on the *raw* data for the rise segment
+    and the plateau segment.  Physics gating (slope-drop ratio, minimum
+    plateau duration, minimum velocity) filters false positives.
+    Selected by ``method="rdp_linear"`` or as the default when
+    ``hel_slope_drop_ratio`` is provided.
+    Documented in ``HEL_DETECTION_ALGORITHM.md`` of HELIX Toolbox.
+"""
+
 from __future__ import annotations
 
 import numpy as np
 from scipy.ndimage import uniform_filter1d
-from dataclasses import dataclass
+from scipy.stats import linregress
+from dataclasses import dataclass, field
 import logging
 
 logger = logging.getLogger("alpss")
@@ -21,13 +40,19 @@ class HELResult:
     segment_duration_ns: float = np.nan
     strain_rate: float = np.nan
     error_message: str | None = None
-    # Internal data for plotting
+    # Internal data for plotting (gradient method)
     segment_start_idx: int | None = None
     segment_end_idx: int | None = None
     time_window: np.ndarray | None = None
     velocity_window: np.ndarray | None = None
     gradient_smooth: np.ndarray | None = None
     angles_deg: np.ndarray | None = None
+    # Extra fields populated by the RDP + Linear Hybrid method
+    method: str = "gradient"
+    rise_slope: float = np.nan       # [m/s per ns] slope of the rise segment
+    plateau_slope: float = np.nan    # [m/s per ns] slope of the plateau segment
+    rdp_knee_time_ns: float = np.nan # time of the RDP knee point [ns]
+    rdp_points: np.ndarray | None = None  # simplified vertices for visualisation
 
 
 def elastic_shock_strain_rate(C_L, U_hel, U_0, t_hel, t_0):
@@ -71,9 +96,24 @@ def hel_detection(
     density=None,
     acoustic_velocity=None,
     C_L=None,
+    # RDP + Linear Hybrid parameters (ignored when method="gradient")
+    method: str = "gradient",
+    hel_rdp_epsilon: float = 1.25,
+    hel_slope_drop_ratio: float = 0.9,
+    hel_min_plateau_duration: float = 0.5,
 ):
     """
     Detect the Hugoniot Elastic Limit (HEL) from a velocity trace.
+
+    Parameters
+    ----------
+    method : str
+        ``"gradient"`` (default, original) or ``"rdp_linear"`` (RDP + Linear
+        Hybrid from HELIX Toolbox v2).  When ``"rdp_linear"`` is requested
+        the gradient-based fall-back is attempted automatically if the hybrid
+        method fails.
+
+    .. rubric:: Gradient method parameters
 
     Uses a gradient-based method to find the earliest low-slope plateau
     in the velocity signal within a specified time window.
@@ -111,6 +151,22 @@ def hel_detection(
     HELResult
         Dataclass with detection results and internal data for plotting.
     """
+    # Delegate to RDP + Linear Hybrid when requested
+    if method == "rdp_linear":
+        return hel_detection_rdp_hybrid(
+            time_ns, velocity, uncertainty,
+            hel_start_ns=hel_start_ns,
+            hel_end_ns=hel_end_ns,
+            min_velocity=min_velocity,
+            density=density,
+            acoustic_velocity=acoustic_velocity,
+            C_L=C_L,
+            rdp_epsilon=hel_rdp_epsilon,
+            slope_drop_ratio=hel_slope_drop_ratio,
+            min_plateau_duration_ns=hel_min_plateau_duration,
+            min_points=min_points,
+        )
+
     time_ns = np.asarray(time_ns, dtype=float)
     velocity = np.asarray(velocity, dtype=float)
     uncertainty = np.asarray(uncertainty, dtype=float)
@@ -256,6 +312,7 @@ def hel_detection(
 
     return HELResult(
         ok=True,
+        method="gradient",
         strength_gpa=strength_gpa,
         uncertainty_gpa=uncertainty_gpa,
         free_surface_velocity=fsv,
@@ -270,3 +327,264 @@ def hel_detection(
         gradient_smooth=gradient_smooth,
         angles_deg=angles_deg,
     )
+
+
+# ---------------------------------------------------------------------------
+# RDP + Linear Hybrid HEL detection (HELIX Toolbox v2 algorithm)
+# ---------------------------------------------------------------------------
+
+def _rdp_hel(points: np.ndarray, epsilon: float) -> np.ndarray:
+    """RDP simplification returning kept indices (shared with spall module)."""
+    if len(points) < 3:
+        return np.arange(len(points))
+
+    def _perp(pt, s, e):
+        if np.allclose(s, e):
+            return np.linalg.norm(pt - s)
+        d = e - s
+        proj = s + np.dot(pt - s, d) / np.dot(d, d) * d
+        return np.linalg.norm(pt - proj)
+
+    def _rec(pts, eps, off=0):
+        if len(pts) < 3:
+            return list(range(off, off + len(pts)))
+        dists = [_perp(pts[i], pts[0], pts[-1]) for i in range(1, len(pts) - 1)]
+        mx = max(dists)
+        mi = dists.index(mx) + 1
+        if mx > eps:
+            L = _rec(pts[: mi + 1], eps, off)
+            R = _rec(pts[mi:], eps, off + mi)
+            return L[:-1] + R
+        return [off, off + len(pts) - 1]
+
+    return np.array(sorted(set(_rec(points, epsilon))))
+
+
+def hel_detection_rdp_hybrid(
+    time_ns,
+    velocity,
+    uncertainty,
+    *,
+    hel_start_ns: float = 0.0,
+    hel_end_ns: float | None = None,
+    min_velocity: float = 10.0,
+    density: float | None = None,
+    acoustic_velocity: float | None = None,
+    C_L: float | None = None,
+    rdp_epsilon: float = 1.25,
+    slope_drop_ratio: float = 0.9,
+    min_plateau_duration_ns: float = 0.5,
+    min_points: int = 10,
+) -> HELResult:
+    """RDP + Linear Hybrid HEL detection (HELIX Toolbox v2 algorithm).
+
+    This method is more robust than the gradient approach because it fits
+    linear regressions on the *raw* data rather than on a smoothed gradient,
+    and applies explicit physics gating criteria.
+
+    Algorithm
+    ---------
+    1. **Time-zero alignment**: clip data to ``[hel_start_ns, hel_end_ns]``.
+    2. **Uncertainty filtering**: discard points where ``|unc|/max|vel| ≥ 1``.
+    3. **RDP simplification**: obtain candidate knee points.
+    4. For each candidate knee point:
+
+       a. Fit a line to the *rise* segment (raw data before the knee).
+       b. Fit a line to the *plateau* segment (raw data after the knee).
+       c. Physics validation:
+
+          * Rise slope must be positive.
+          * ``plateau_slope < (1 − slope_drop_ratio) × rise_slope``
+            (default: plateau slope < 10 % of rise slope).
+          * Plateau must last ≥ ``min_plateau_duration_ns`` ns.
+          * Plateau mean velocity must exceed ``min_velocity``.
+          * Elastic strain rate must be positive.
+
+    5. Accept the first knee that passes all checks.
+
+    Parameters
+    ----------
+    time_ns:
+        Time array in **nanoseconds**.
+    velocity:
+        Smoothed velocity array  [m/s].
+    uncertainty:
+        Velocity uncertainty array  [m/s].
+    hel_start_ns, hel_end_ns:
+        Search window  [ns].
+    min_velocity:
+        Minimum accepted HEL plateau velocity  [m/s].
+    density:
+        Material density  [kg/m³] — needed for stress output.
+    acoustic_velocity:
+        Bulk wave speed  [m/s] — needed for stress output.
+    C_L:
+        Longitudinal wave speed  [m/s] — used for strain rate;
+        falls back to ``acoustic_velocity``.
+    rdp_epsilon:
+        RDP tolerance  [m/s].
+    slope_drop_ratio:
+        Fraction of rise slope that the plateau slope must fall below.
+        E.g. 0.9 means ``|plateau_slope| < 10 %`` of ``|rise_slope|``.
+    min_plateau_duration_ns:
+        Minimum plateau duration  [ns].
+    min_points:
+        Minimum number of raw data points in the plateau segment.
+
+    Returns
+    -------
+    HELResult
+        Falls back to ``hel_detection(..., method="gradient")`` if no knee
+        passes the physics checks.
+    """
+    time_ns = np.asarray(time_ns, dtype=float)
+    velocity = np.asarray(velocity, dtype=float)
+    uncertainty = np.asarray(uncertainty, dtype=float)
+
+    # ------------------------------------------------------------------ #
+    # 1–2  Filter + window                                                  #
+    # ------------------------------------------------------------------ #
+    valid = ~np.isnan(velocity)
+    if valid.sum() <= 5:
+        return HELResult(ok=False, error_message="insufficient valid data for HEL (RDP method)")
+
+    t_c = time_ns[valid]
+    v_c = velocity[valid]
+    u_c = uncertainty[valid]
+
+    max_v = np.max(np.abs(v_c))
+    rel_unc = np.abs(u_c) / max(max_v, 1e-9)
+    good = rel_unc < 1.0
+    if good.sum() >= 10:
+        t_c, v_c, u_c = t_c[good], v_c[good], u_c[good]
+
+    win = t_c >= hel_start_ns
+    if hel_end_ns is not None and hel_end_ns > hel_start_ns:
+        win &= t_c <= hel_end_ns
+    if win.sum() < 10:
+        win = np.ones(len(t_c), dtype=bool)
+
+    t_w, v_w, u_w = t_c[win], v_c[win], u_c[win]
+    if len(t_w) < 10:
+        return HELResult(ok=False, method="rdp_linear",
+                         error_message="insufficient data in HEL window (RDP method)")
+
+    # ------------------------------------------------------------------ #
+    # 3  RDP simplification                                                 #
+    # ------------------------------------------------------------------ #
+    pts = np.column_stack((t_w, v_w))
+    rdp_idx = _rdp_hel(pts, rdp_epsilon)
+    rdp_pts = pts[rdp_idx]
+
+    if len(rdp_pts) < 3:
+        return HELResult(ok=False, method="rdp_linear",
+                         error_message="RDP produced fewer than 3 vertices — trace too smooth")
+
+    # ------------------------------------------------------------------ #
+    # 4  Candidate knee scan                                                #
+    # ------------------------------------------------------------------ #
+    if C_L is None:
+        C_L = acoustic_velocity
+
+    best: HELResult | None = None
+
+    for ki in range(1, len(rdp_pts) - 1):
+        knee_t = float(rdp_pts[ki, 0])
+
+        # Rise segment: raw points up to and including the knee
+        rise_mask = t_w <= knee_t
+        plat_mask = t_w >= knee_t
+        if rise_mask.sum() < 3 or plat_mask.sum() < min_points:
+            continue
+
+        # Linear fit on raw data
+        try:
+            r_slope, _, _, _, _ = linregress(t_w[rise_mask], v_w[rise_mask])
+            p_slope, _, _, _, _ = linregress(t_w[plat_mask], v_w[plat_mask])
+        except Exception:
+            continue
+
+        # Physics gate: positive rise, flat/negative plateau
+        if r_slope <= 0:
+            continue
+        if abs(p_slope) >= (1.0 - slope_drop_ratio) * abs(r_slope):
+            continue
+
+        # Plateau duration
+        plat_duration = float(t_w[plat_mask][-1] - t_w[plat_mask][0])
+        if plat_duration < min_plateau_duration_ns:
+            continue
+
+        # HEL velocity (mean of plateau raw data)
+        fsv = float(np.mean(v_w[plat_mask]))
+        if abs(fsv) < min_velocity:
+            continue
+
+        # Strain rate (must be positive)
+        if C_L is not None:
+            # reference point: first window sample
+            U_0 = float(v_w[0])
+            t_0 = float(t_w[0])
+            sr = elastic_shock_strain_rate(C_L, fsv, U_0, knee_t, t_0)
+            if sr <= 0:
+                continue
+        else:
+            sr = np.nan
+
+        # Uncertainty: mean uncertainty of plateau raw points
+        u_unc = float(np.mean(np.abs(u_w[plat_mask])))
+
+        # Stress
+        strength_gpa = np.nan
+        unc_gpa = np.nan
+        if density is not None and acoustic_velocity is not None:
+            strength_gpa = 0.5 * density * acoustic_velocity * abs(fsv) / 1e9
+            unc_gpa = 0.5 * density * acoustic_velocity * u_unc / 1e9
+
+        best = HELResult(
+            ok=True,
+            method="rdp_linear",
+            strength_gpa=strength_gpa,
+            uncertainty_gpa=unc_gpa,
+            free_surface_velocity=fsv,
+            time_detection_ns=knee_t,
+            consecutive_points=int(plat_mask.sum()),
+            segment_duration_ns=plat_duration,
+            strain_rate=sr,
+            rise_slope=float(r_slope),
+            plateau_slope=float(p_slope),
+            rdp_knee_time_ns=knee_t,
+            rdp_points=rdp_pts,
+            time_window=t_w,
+            velocity_window=v_w,
+        )
+        break  # accept first valid knee
+
+    if best is not None:
+        logger.info(
+            "[RDP-Linear] HEL %.3f GPa at %.1f ns (rise=%.2f, plateau=%.2f m/s/ns)",
+            best.strength_gpa,
+            best.time_detection_ns,
+            best.rise_slope,
+            best.plateau_slope,
+        )
+        return best
+
+    # ------------------------------------------------------------------ #
+    # 5  Fall back to gradient method                                       #
+    # ------------------------------------------------------------------ #
+    logger.info("[RDP-Linear] No valid HEL knee found — falling back to gradient method")
+    result = hel_detection(
+        time_ns, velocity, uncertainty,
+        hel_start_ns=hel_start_ns,
+        hel_end_ns=hel_end_ns,
+        min_velocity=min_velocity,
+        density=density,
+        acoustic_velocity=acoustic_velocity,
+        C_L=C_L,
+        method="gradient",
+    )
+    if not result.ok and result.error_message and "rdp" not in result.error_message.lower():
+        result.error_message = "RDP+Linear: no valid knee; gradient fallback: " + (result.error_message or "no plateau")
+    result.method = "gradient_fallback"
+    return result

--- a/src/alpss/analysis/spall.py
+++ b/src/alpss/analysis/spall.py
@@ -1,6 +1,423 @@
+"""Spall analysis for PDV velocity traces.
+
+This module contains two levels of analysis:
+
+* :func:`spall_analysis` — original peak/valley finder (unchanged, backward-compatible).
+* :func:`spall_analysis_with_dns` — extended version that adds:
+    - RDP topology check ("checkmark" Plateau→Pullback→Rebound scanner)
+    - DNS (Did Not Spall) qualification
+    - :class:`SpallResult` return type with structured fields
+
+The RDP topology approach is ported from HELIX Toolbox v2 (Wanchoo, 2026) and
+mirrors the algorithm documented in ``SPALL_DETECTION_ALGORITHM.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
 import numpy as np
 from scipy import signal
 
+logger = logging.getLogger("alpss")
+
+
+# ---------------------------------------------------------------------------
+# SpallResult dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SpallResult:
+    """Structured return type for :func:`spall_analysis_with_dns`.
+
+    Attributes
+    ----------
+    ok : bool
+        ``True`` if a valid spall event was detected.
+    dns_classification : str
+        ``"Valid Spall"`` or a string explaining why the event is DNS.
+    spall_strength_pa : float
+        Spall strength in **Pa** (divide by 1e9 for GPa).
+    spall_strength_unc_pa : float
+        1-σ uncertainty in Pa.
+    strain_rate : float
+        Spall strain rate  [s⁻¹].
+    peak_velocity : float
+        Peak (plateau) free-surface velocity  [m/s].
+    pullback_velocity : float
+        |v_peak − v_min|  [m/s].
+    t_peak : float
+        Time of peak velocity  [s].
+    t_pullback : float
+        Time of minimum (pullback) velocity  [s].
+    t_recompression : float
+        Time of first recompression maximum  [s].
+    v_peak : float
+        Peak velocity  [m/s].
+    v_pullback : float
+        Pullback (minimum) velocity  [m/s].
+    v_recompression : float
+        Recompression velocity  [m/s].
+    rdp_points : np.ndarray or None
+        RDP-simplified (time, velocity) vertices used for topology check.
+    error_message : str or None
+        Human-readable failure reason (``None`` on success).
+    """
+
+    ok: bool = False
+    dns_classification: str = "Unknown"
+    spall_strength_pa: float = np.nan
+    spall_strength_unc_pa: float = np.nan
+    strain_rate: float = np.nan
+    peak_velocity: float = np.nan
+    pullback_velocity: float = np.nan
+    t_peak: float = np.nan
+    t_pullback: float = np.nan
+    t_recompression: float = np.nan
+    v_peak: float = np.nan
+    v_pullback: float = np.nan
+    v_recompression: float = np.nan
+    rdp_points: np.ndarray | None = None
+    error_message: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# RDP helper
+# ---------------------------------------------------------------------------
+
+def _rdp_simplify(
+    points: np.ndarray,
+    epsilon: float,
+) -> np.ndarray:
+    """Ramer–Douglas–Peucker polyline simplification.
+
+    Parameters
+    ----------
+    points:
+        (N, 2) array of (x, y) vertices.
+    epsilon:
+        Perpendicular-distance tolerance.
+
+    Returns
+    -------
+    np.ndarray
+        Indices (into *points*) of the retained vertices.
+    """
+    if len(points) < 3:
+        return np.arange(len(points))
+
+    def _perp_distance(point, start, end):
+        if np.allclose(start, end):
+            return np.linalg.norm(point - start)
+        d = end - start
+        t = np.dot(point - start, d) / np.dot(d, d)
+        proj = start + t * d
+        return np.linalg.norm(point - proj)
+
+    def _rdp_recursive(pts, eps, idx_offset=0):
+        if len(pts) < 3:
+            return list(range(idx_offset, idx_offset + len(pts)))
+        start, end = pts[0], pts[-1]
+        dists = [_perp_distance(pts[i], start, end) for i in range(1, len(pts) - 1)]
+        max_d = max(dists)
+        max_i = dists.index(max_d) + 1
+        if max_d > eps:
+            left = _rdp_recursive(pts[: max_i + 1], eps, idx_offset)
+            right = _rdp_recursive(pts[max_i:], eps, idx_offset + max_i)
+            return left[:-1] + right
+        return [idx_offset, idx_offset + len(pts) - 1]
+
+    indices = _rdp_recursive(points, epsilon)
+    return np.array(sorted(set(indices)))
+
+
+# ---------------------------------------------------------------------------
+# Spall topology ("checkmark") detector
+# ---------------------------------------------------------------------------
+
+def _detect_spall_topology(
+    time_ns: np.ndarray,
+    velocity: np.ndarray,
+    rdp_epsilon: float = 5.0,
+    min_pullback_velocity: float = 10.0,
+    min_recomp_ratio: float = 0.03,
+    min_recomp_velocity_ratio: float = 1.10,
+    min_recomp_time_ns: float = 2.5,
+) -> tuple[bool, str, dict | None, np.ndarray | None]:
+    """Scan a velocity trace for the spall "checkmark" topology.
+
+    The expected shape is:  plateau  →  pullback  →  rebound.
+
+    Algorithm
+    ---------
+    1. Apply RDP simplification to the trace.
+    2. Find the global peak in the simplified vertices.
+    3. Find the first subsequent minimum (pullback).
+    4. Find the first subsequent maximum (rebound).
+    5. Validate physical gating criteria.
+
+    Parameters
+    ----------
+    time_ns:
+        Time array in **nanoseconds**.
+    velocity:
+        Smoothed velocity array  [m/s].
+    rdp_epsilon:
+        RDP tolerance  [m/s].
+    min_pullback_velocity:
+        Minimum pullback depth to accept  [m/s].
+    min_recomp_ratio:
+        Rebound must reach ≥ this fraction of the pullback depth.
+    min_recomp_velocity_ratio:
+        Rebound velocity must exceed the valley velocity by this ratio.
+    min_recomp_time_ns:
+        Minimum sustained duration of the rebound  [ns].
+
+    Returns
+    -------
+    (is_spall, reason, keys, rdp_points)
+        * ``is_spall`` – ``True`` if the topology matches.
+        * ``reason``   – description string.
+        * ``keys``     – dict with detected indices/velocities, or ``None``.
+        * ``rdp_points`` – (M, 2) simplified vertices for visualisation.
+    """
+    time_ns = np.asarray(time_ns, dtype=float)
+    velocity = np.asarray(velocity, dtype=float)
+
+    pts = np.column_stack((time_ns, velocity))
+    rdp_idx = _rdp_simplify(pts, rdp_epsilon)
+    rdp_pts = pts[rdp_idx]
+
+    if len(rdp_pts) < 4:
+        return False, "RDP produced fewer than 4 vertices — trace too flat", None, rdp_pts
+
+    rdp_vel = rdp_pts[:, 1]
+
+    # Global peak in RDP vertices
+    peak_rdp = int(np.argmax(rdp_vel))
+    v_peak = float(rdp_vel[peak_rdp])
+    t_peak = float(rdp_pts[peak_rdp, 0])
+
+    if peak_rdp >= len(rdp_pts) - 2:
+        return False, "Peak is at or near the end of the trace — no room for pullback", None, rdp_pts
+
+    # Minimum after peak (pullback)
+    seg_after_peak = rdp_vel[peak_rdp + 1:]
+    if len(seg_after_peak) == 0:
+        return False, "No RDP vertices after peak", None, rdp_pts
+    min_rel = int(np.argmin(seg_after_peak))
+    pullback_rdp = peak_rdp + 1 + min_rel
+    v_pullback = float(rdp_vel[pullback_rdp])
+    t_pullback = float(rdp_pts[pullback_rdp, 0])
+
+    pullback_depth = v_peak - v_pullback
+    if pullback_depth < min_pullback_velocity:
+        return (
+            False,
+            f"Pullback depth {pullback_depth:.2f} m/s < minimum {min_pullback_velocity:.2f} m/s",
+            None,
+            rdp_pts,
+        )
+
+    # Maximum after pullback (rebound / recompression)
+    seg_after_pullback = rdp_vel[pullback_rdp + 1:]
+    if len(seg_after_pullback) == 0:
+        return False, "No RDP vertices after pullback — no rebound detected", None, rdp_pts
+    max_rel = int(np.argmax(seg_after_pullback))
+    rebound_rdp = pullback_rdp + 1 + max_rel
+    v_rebound = float(rdp_vel[rebound_rdp])
+    t_rebound = float(rdp_pts[rebound_rdp, 0])
+
+    # Gating: recompression must be meaningful
+    recomp_rise = v_rebound - v_pullback
+    if recomp_rise < min_recomp_ratio * pullback_depth:
+        return (
+            False,
+            f"Rebound rise {recomp_rise:.2f} m/s is < {min_recomp_ratio*100:.0f}% of pullback — no re-acceleration",
+            None,
+            rdp_pts,
+        )
+    if v_rebound < min_recomp_velocity_ratio * v_pullback:
+        return (
+            False,
+            f"Rebound velocity {v_rebound:.2f} m/s ≤ {min_recomp_velocity_ratio}× valley velocity {v_pullback:.2f} m/s",
+            None,
+            rdp_pts,
+        )
+    if (t_rebound - t_pullback) < min_recomp_time_ns:
+        return (
+            False,
+            f"Rebound lasts only {t_rebound - t_pullback:.2f} ns (< {min_recomp_time_ns} ns minimum)",
+            None,
+            rdp_pts,
+        )
+
+    keys = {
+        "shock_peak_idx": int(rdp_idx[peak_rdp]),
+        "pullback_idx": int(rdp_idx[pullback_rdp]),
+        "rebound_idx": int(rdp_idx[rebound_rdp]),
+        "peak_velocity": v_peak,
+        "pullback_velocity": v_pullback,
+        "rebound_velocity": v_rebound,
+        "t_peak_ns": t_peak,
+        "t_pullback_ns": t_pullback,
+        "t_rebound_ns": t_rebound,
+        "pullback_depth": pullback_depth,
+    }
+    return True, "Valid spall topology detected", keys, rdp_pts
+
+
+# ---------------------------------------------------------------------------
+# Extended spall analysis with DNS qualifier
+# ---------------------------------------------------------------------------
+
+def spall_analysis_with_dns(
+    vc_out: dict,
+    iua_out: dict,
+    *,
+    spall_detection_method: str = "rdp",
+    rdp_epsilon: float = 5.0,
+    min_pullback_velocity: float = 10.0,
+    min_recomp_ratio: float = 0.03,
+    min_recomp_velocity_ratio: float = 1.10,
+    min_recomp_time_ns: float = 2.5,
+    **inputs,
+) -> SpallResult:
+    """Spall analysis with DNS (Did Not Spall) qualification.
+
+    Wraps :func:`spall_analysis` and adds an RDP topology check to classify
+    whether the event genuinely spalled.
+
+    Parameters
+    ----------
+    vc_out:
+        Velocity output dict from ``velocity_calculation``
+        (keys: ``time_f`` [s], ``velocity_f_smooth`` [m/s]).
+    iua_out:
+        Uncertainty output dict (keys: ``freq_uncert``, ``vel_uncert``).
+    spall_detection_method:
+        ``"rdp"`` (default) — use RDP topology check before peak/valley;
+        ``"max_min"``       — skip topology check, use peak/valley only.
+    rdp_epsilon:
+        RDP tolerance  [m/s].
+    min_pullback_velocity, min_recomp_ratio, min_recomp_velocity_ratio, min_recomp_time_ns:
+        Physical gating thresholds (see :func:`_detect_spall_topology`).
+    **inputs:
+        Same keyword arguments accepted by :func:`spall_analysis`
+        (``spall_calculation``, ``pb_neighbors``, ``pb_idx_correction``,
+        ``C0``, ``density``, …).
+
+    Returns
+    -------
+    SpallResult
+    """
+    result = SpallResult()
+
+    if inputs.get("spall_calculation", "yes") != "yes":
+        result.dns_classification = "Spall calculation disabled"
+        return result
+
+    time_s = vc_out["time_f"]
+    vel = vc_out["velocity_f_smooth"]
+    vel_unc = iua_out["vel_uncert"]
+    C0 = inputs["C0"]
+    density = inputs["density"]
+
+    # ------------------------------------------------------------------ #
+    # Step 1: RDP topology check (optional)                                #
+    # ------------------------------------------------------------------ #
+    rdp_points = None
+    if spall_detection_method.lower() == "rdp":
+        time_ns = time_s * 1e9
+        is_spall, reason, rdp_keys, rdp_points = _detect_spall_topology(
+            time_ns, vel,
+            rdp_epsilon=rdp_epsilon,
+            min_pullback_velocity=min_pullback_velocity,
+            min_recomp_ratio=min_recomp_ratio,
+            min_recomp_velocity_ratio=min_recomp_velocity_ratio,
+            min_recomp_time_ns=min_recomp_time_ns,
+        )
+        result.rdp_points = rdp_points
+        if not is_spall:
+            result.ok = False
+            result.dns_classification = reason
+            result.error_message = reason
+            logger.info("DNS: %s", reason)
+            # Still try to extract peak velocity for shock stress
+            try:
+                result.v_peak = float(np.max(vel))
+                result.peak_velocity = result.v_peak
+            except Exception:
+                pass
+            return result
+
+    # ------------------------------------------------------------------ #
+    # Step 2: Peak / valley analysis (existing logic)                      #
+    # ------------------------------------------------------------------ #
+    try:
+        sa = spall_analysis(vc_out, iua_out, **inputs)
+    except Exception as exc:
+        result.ok = False
+        result.dns_classification = str(exc)
+        result.error_message = str(exc)
+        logger.warning("spall_analysis failed: %s", exc)
+        return result
+
+    # ------------------------------------------------------------------ #
+    # Step 3: Post-analysis DNS checks                                     #
+    # ------------------------------------------------------------------ #
+    v_peak = sa["v_max_comp"]
+    v_pullback_min = sa["v_max_ten"]
+    pullback_depth = v_peak - v_pullback_min
+
+    if np.isnan(v_peak) or np.isnan(v_pullback_min):
+        result.ok = False
+        result.dns_classification = "Peak or pullback velocity could not be determined"
+        result.error_message = result.dns_classification
+        return result
+
+    if pullback_depth < min_pullback_velocity:
+        result.ok = False
+        result.dns_classification = (
+            f"Pullback depth {pullback_depth:.2f} m/s < minimum "
+            f"{min_pullback_velocity:.2f} m/s"
+        )
+        result.error_message = result.dns_classification
+        logger.info("DNS (post-analysis): %s", result.dns_classification)
+    else:
+        result.ok = True
+        result.dns_classification = "Valid Spall"
+
+    # ------------------------------------------------------------------ #
+    # Step 4: Propagate results                                            #
+    # ------------------------------------------------------------------ #
+    result.v_peak = float(v_peak)
+    result.peak_velocity = float(v_peak)
+    result.v_pullback = float(v_pullback_min)
+    result.v_recompression = float(sa["v_rc"]) if not np.isnan(sa["v_rc"]) else np.nan
+    result.t_peak = float(sa["t_max_comp"])
+    result.t_pullback = float(sa["t_max_ten"])
+    result.t_recompression = float(sa["t_rc"]) if not np.isnan(sa["t_rc"]) else np.nan
+    result.pullback_velocity = float(pullback_depth)
+    result.spall_strength_pa = float(sa["spall_strength_est"])
+
+    # Uncertainty: propagate peak + pullback velocity uncertainties
+    peak_unc = float(vel_unc[int(np.argmax(vel))]) if not np.isnan(v_peak) else 0.0
+    pullback_idx = np.argmin(np.abs(time_s - sa["t_max_ten"]))
+    pullback_unc = float(vel_unc[pullback_idx])
+    result.spall_strength_unc_pa = (
+        0.5 * density * C0 * np.sqrt(peak_unc**2 + pullback_unc**2)
+    )
+
+    result.strain_rate = float(sa["strain_rate_est"])
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Original spall analysis (unchanged — backward-compatible)
+# ---------------------------------------------------------------------------
 
 # function to pull out important points on the spall signal
 def spall_analysis(vc_out, iua_out, **inputs):

--- a/tests/test_hel_rdp.py
+++ b/tests/test_hel_rdp.py
@@ -1,0 +1,108 @@
+import pytest
+import numpy as np
+
+from alpss.analysis.hel import hel_detection, hel_detection_rdp_hybrid, HELResult
+
+
+@pytest.fixture
+def synthetic_hel_signal():
+    """Synthetic PDV trace with a sharp HEL knee at ~4 ns."""
+    np.random.seed(7)
+    t = np.linspace(-2, 25, 200)
+    v = np.zeros_like(t)
+
+    # Baseline noise before t=0
+    v[t < 0] = np.random.normal(0, 0.5, (t < 0).sum())
+
+    # Steep rise to HEL plateau (0–4 ns)
+    rise_mask = (t >= 0) & (t < 4)
+    v[rise_mask] = 160 * t[rise_mask] / 4 + np.random.normal(0, 0.3, rise_mask.sum())
+
+    # HEL plateau (4–12 ns) at ~160 m/s
+    plat_mask = (t >= 4) & (t < 12)
+    v[plat_mask] = 160 + np.random.normal(0, 0.5, plat_mask.sum())
+
+    # Ramp to peak (12–25 ns)
+    ramp_mask = t >= 12
+    v[ramp_mask] = 160 + 30 * (t[ramp_mask] - 12) + np.random.normal(0, 1, ramp_mask.sum())
+
+    unc = np.ones_like(v) * 5.0
+    return t, v, unc
+
+
+class TestHELRDPHybrid:
+    def test_detects_hel_in_synthetic(self, synthetic_hel_signal):
+        t, v, u = synthetic_hel_signal
+        result = hel_detection_rdp_hybrid(
+            t, v, u,
+            hel_start_ns=0.0, hel_end_ns=15.0,
+            min_velocity=50.0,
+            density=8960, acoustic_velocity=3950, C_L=4700,
+            rdp_epsilon=2.0,
+            slope_drop_ratio=0.85,
+            min_plateau_duration_ns=0.5,
+            min_points=5,
+        )
+        assert result.ok is True
+        assert result.method in ("rdp_linear", "gradient_fallback")
+        assert result.strength_gpa > 0
+        assert result.free_surface_velocity == pytest.approx(160, abs=15)
+
+    def test_strain_rate_is_positive(self, synthetic_hel_signal):
+        t, v, u = synthetic_hel_signal
+        result = hel_detection_rdp_hybrid(
+            t, v, u,
+            hel_start_ns=0.0, hel_end_ns=15.0,
+            min_velocity=50.0, C_L=4700,
+            rdp_epsilon=2.0,
+        )
+        if result.ok:
+            assert result.strain_rate > 0
+
+    def test_returns_helresult_always(self, synthetic_hel_signal):
+        t, v, u = synthetic_hel_signal
+        result = hel_detection_rdp_hybrid(t, v, u, min_velocity=9999.0)
+        assert isinstance(result, HELResult)
+
+    def test_fallback_on_flat_signal(self):
+        t = np.linspace(0, 20, 200)
+        v = np.ones(200) * 100.0
+        u = np.ones(200) * 2.0
+        result = hel_detection_rdp_hybrid(t, v, u, min_velocity=50.0)
+        assert isinstance(result, HELResult)
+        assert result.method in ("rdp_linear", "gradient", "gradient_fallback")
+
+    def test_rdp_points_stored_when_ok(self, synthetic_hel_signal):
+        t, v, u = synthetic_hel_signal
+        result = hel_detection_rdp_hybrid(
+            t, v, u, hel_start_ns=0.0, hel_end_ns=15.0,
+            min_velocity=50.0, rdp_epsilon=2.0,
+        )
+        if result.ok and result.method == "rdp_linear":
+            assert result.rdp_points is not None
+            assert result.rdp_points.shape[1] == 2
+
+    def test_hel_detection_dispatches_to_hybrid(self, synthetic_hel_signal):
+        """hel_detection(method='rdp_linear') should delegate correctly."""
+        t, v, u = synthetic_hel_signal
+        result = hel_detection(
+            t, v, u,
+            hel_start_ns=0.0, hel_end_ns=15.0,
+            min_velocity=50.0, method="rdp_linear",
+            density=8960, acoustic_velocity=3950,
+            hel_rdp_epsilon=2.0,
+        )
+        assert isinstance(result, HELResult)
+        assert result.method in ("rdp_linear", "gradient_fallback", "gradient")
+
+    def test_hel_detection_gradient_still_works(self, synthetic_hel_signal):
+        """Original gradient method must be unaffected."""
+        t, v, u = synthetic_hel_signal
+        result = hel_detection(
+            t, v, u,
+            hel_start_ns=0.0, hel_end_ns=15.0,
+            min_velocity=50.0, method="gradient",
+            density=8960, acoustic_velocity=3950,
+        )
+        assert isinstance(result, HELResult)
+        assert result.method == "gradient"

--- a/tests/test_spall_dns.py
+++ b/tests/test_spall_dns.py
@@ -1,0 +1,143 @@
+import pytest
+import numpy as np
+
+from alpss.analysis.spall import (
+    _rdp_simplify,
+    _detect_spall_topology,
+    spall_analysis_with_dns,
+    SpallResult,
+)
+
+
+class TestRDPSimplify:
+    def test_straight_line_collapses_to_endpoints(self):
+        t = np.linspace(0, 10, 100)
+        v = 3.0 * t + 1.0
+        pts = np.column_stack((t, v))
+        idx = _rdp_simplify(pts, epsilon=0.01)
+        assert len(idx) == 2
+
+    def test_fewer_than_3_points_returned_as_is(self):
+        pts = np.array([[0, 0], [1, 1]])
+        idx = _rdp_simplify(pts, epsilon=1.0)
+        assert len(idx) == 2
+
+    def test_checkmark_shape_preserves_key_vertices(self):
+        t = np.linspace(0, 50, 500)
+        v = np.zeros_like(t)
+        v[t <= 10] = 500.0
+        v[(t > 10) & (t <= 25)] = 500 - 25 * (t[(t > 10) & (t <= 25)] - 10)
+        v[t > 25] = 125 + 5 * (t[t > 25] - 25)
+        pts = np.column_stack((t, v))
+        idx = _rdp_simplify(pts, epsilon=5.0)
+        assert len(idx) >= 3
+
+
+class TestDetectSpallTopology:
+    @pytest.fixture
+    def valid_checkmark(self):
+        t = np.linspace(0, 80, 800)
+        v = np.zeros_like(t)
+        v[t <= 15] = 500.0
+        v[(t > 15) & (t <= 35)] = 500 - 20 * (t[(t > 15) & (t <= 35)] - 15)
+        v[t > 35] = 100 + 8 * (t[t > 35] - 35)
+        return t, v
+
+    def test_valid_spall_detected(self, valid_checkmark):
+        t, v = valid_checkmark
+        ok, reason, keys, pts = _detect_spall_topology(t, v, rdp_epsilon=5.0,
+                                                        min_pullback_velocity=30.0,
+                                                        min_recomp_ratio=0.01,
+                                                        min_recomp_velocity_ratio=1.01,
+                                                        min_recomp_time_ns=1.0)
+        assert ok is True
+        assert keys is not None
+        assert keys["pullback_depth"] > 30
+
+    def test_returns_false_for_flat_signal(self):
+        t = np.linspace(0, 50, 500)
+        v = np.ones(500) * 200.0
+        ok, reason, keys, _ = _detect_spall_topology(t, v, rdp_epsilon=2.0)
+        assert ok is False
+
+    def test_returns_false_when_pullback_too_small(self, valid_checkmark):
+        t, v = valid_checkmark
+        ok, reason, keys, _ = _detect_spall_topology(
+            t, v, rdp_epsilon=5.0, min_pullback_velocity=9999.0
+        )
+        assert ok is False
+        assert "pullback" in reason.lower() or "minimum" in reason.lower()
+
+    def test_rdp_points_returned_on_failure(self):
+        t = np.linspace(0, 50, 100)
+        v = np.ones(100) * 100.0
+        ok, reason, keys, rdp_pts = _detect_spall_topology(t, v)
+        assert rdp_pts is not None
+
+
+class TestSpallAnalysisWithDNS:
+    @pytest.fixture
+    def vc_iua(self):
+        np.random.seed(0)
+        t = np.linspace(0, 80e-9, 800)
+        v = np.zeros(800)
+        v[t <= 15e-9] = 500.0
+        drop_mask = (t > 15e-9) & (t <= 35e-9)
+        v[drop_mask] = 500 - 20 * (t[drop_mask] - 15e-9) / 1e-9
+        v[t > 35e-9] = 100 + 8 * (t[t > 35e-9] - 35e-9) / 1e-9
+        v += np.random.normal(0, 2, 800)
+        vc = {"time_f": t, "velocity_f_smooth": v}
+        iua = {"vel_uncert": np.ones(800) * 5.0, "freq_uncert": np.ones(800) * 1e6}
+        return vc, iua
+
+    def test_dns_disabled_returns_early(self):
+        vc = {"time_f": np.zeros(10), "velocity_f_smooth": np.zeros(10)}
+        iua = {"vel_uncert": np.zeros(10), "freq_uncert": np.zeros(10)}
+        r = spall_analysis_with_dns(vc, iua, spall_calculation="no",
+                                    C0=3950, density=8960,
+                                    pb_neighbors=3, pb_idx_correction=0)
+        assert r.ok is False
+        assert "disabled" in r.dns_classification
+
+    def test_valid_spall_classified(self, vc_iua):
+        vc, iua = vc_iua
+        r = spall_analysis_with_dns(
+            vc, iua,
+            spall_detection_method="max_min",
+            spall_calculation="yes",
+            C0=3950, density=8960,
+            pb_neighbors=5, pb_idx_correction=0,
+        )
+        assert isinstance(r, SpallResult)
+        assert r.ok is True
+        assert r.dns_classification == "Valid Spall"
+        assert r.spall_strength_pa > 0
+        assert np.isfinite(r.strain_rate)
+
+    def test_rdp_method_runs(self, vc_iua):
+        vc, iua = vc_iua
+        r = spall_analysis_with_dns(
+            vc, iua,
+            spall_detection_method="rdp",
+            spall_calculation="yes",
+            C0=3950, density=8960,
+            pb_neighbors=5, pb_idx_correction=0,
+            rdp_epsilon=5.0,
+            min_pullback_velocity=10.0,
+        )
+        assert isinstance(r, SpallResult)
+        assert isinstance(r.dns_classification, str)
+
+    def test_spall_result_fields_populated(self, vc_iua):
+        vc, iua = vc_iua
+        r = spall_analysis_with_dns(
+            vc, iua,
+            spall_detection_method="max_min",
+            spall_calculation="yes",
+            C0=3950, density=8960,
+            pb_neighbors=5, pb_idx_correction=0,
+        )
+        assert np.isfinite(r.v_peak)
+        assert np.isfinite(r.v_pullback)
+        assert np.isfinite(r.t_peak)
+        assert np.isfinite(r.t_pullback)


### PR DESCRIPTION
Adds `spall_analysis_with_dns()` which wraps the existing `spall_analysis()` with an optional RDP topology pre-check (plateau→pullback→rebound checkmark) and configurable gating thresholds. Returns a `SpallResult` dataclass with `dns_classification` ("Valid Spall" or failure reason). Stacked on #27.