### PR TITLE
feat: Hugoniot shock stress calculation

### DIFF
--- a/src/alpss/alpss_main.py
+++ b/src/alpss/alpss_main.py
@@ -10,6 +10,7 @@ from alpss.analysis.spall import spall_analysis, spall_analysis_with_dns, SpallR
 from alpss.analysis.full_uncertainty import full_uncertainty_analysis
 from alpss.analysis.instantaneous_uncertainty import instantaneous_uncertainty_analysis
 from alpss.analysis.hel import hel_detection
+from alpss.analysis.shock_stress import calculate_shock_stress
 from alpss.utils import extract_data
 from alpss.io.saving import save
 from datetime import datetime
@@ -202,7 +203,32 @@ def alpss_main(**inputs):
             logger.error("Traceback: %s", traceback.format_exc())
             logger.info("Continuing without uncertainty analysis.")
 
-    # --- Phase 2c: HEL detection (optional) ---
+    # --- Phase 2c: Shock stress (Hugoniot EOS) ---
+    shock_result = {
+        "shock_stress_pa": np.nan, "shock_stress_gpa": np.nan,
+        "shock_stress_unc_pa": np.nan, "shock_stress_unc_gpa": np.nan,
+        "method": "none", "S": np.nan,
+    }
+    peak_velocity = sa_out.get("v_max_comp", np.nan)
+    if np.isfinite(float(peak_velocity)):
+        peak_vel_unc = sa_out.get("peak_velocity_vel_uncert", 0.0) or 0.0
+        shock_result = calculate_shock_stress(
+            density=inputs.get("density", np.nan),
+            C0=inputs.get("C0", np.nan),
+            peak_velocity=peak_velocity,
+            peak_velocity_unc=float(peak_vel_unc),
+            material=inputs.get("material", ""),
+            S=inputs.get("hugoniot_S", None),
+            method=inputs.get("shock_stress_method", "hugoniot"),
+        )
+        logger.info(
+            "Shock stress: %.4f GPa (method=%s, S=%.2f)",
+            shock_result["shock_stress_gpa"],
+            shock_result["method"],
+            shock_result["S"] if not np.isnan(shock_result["S"]) else 0,
+        )
+
+    # --- Phase 2d: HEL detection (optional) ---
     hel_out = _default_hel_output()
     hel_enabled = inputs.get("hel_detection_enabled", False)
     if hel_enabled:
@@ -309,6 +335,7 @@ def alpss_main(**inputs):
         uncertainty_ok=uncertainty_ok,
         error_msg="; ".join(errors) if errors else "",
         spall_result=spall_result,
+        shock_result=shock_result,
         **inputs,
     )
 

--- a/src/alpss/analysis/__init__.py
+++ b/src/alpss/analysis/__init__.py
@@ -13,3 +13,10 @@ from alpss.analysis.hel import (
     elastic_shock_strain_rate,
     HELResult,
 )
+from alpss.analysis.shock_stress import (
+    calculate_shock_stress,
+    shock_stress_hugoniot,
+    shock_stress_acoustic,
+    shock_stress_hugoniot_uncertainty,
+    get_hugoniot_S,
+)

--- a/src/alpss/analysis/shock_stress.py
+++ b/src/alpss/analysis/shock_stress.py
@@ -1,0 +1,235 @@
+"""Shock stress calculations for spall/PDV analysis.
+
+Two methods are provided:
+
+* **Acoustic approximation** (simple):
+    σ = 0.5 · ρ · C₀ · v_peak
+
+* **Hugoniot EOS** (preferred, matches HELIX Toolbox):
+    u_p      = v_fs / 2               (particle velocity from free-surface velocity)
+    U_shock  = C₀ + S · u_p          (linear Hugoniot)
+    σ        = ρ · U_shock · u_p
+
+All functions return stress in **Pa**.  Divide by 1e9 for GPa.
+
+The default S parameter per material is taken from the linear Hugoniot fits
+listed in Meyers, "Dynamic Behavior of Materials" (1994) and Shock Wave Database
+(www.ihed.ras.ru/rusbank).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Hugoniot slope parameter S  (U_s = C₀ + S·u_p)
+# Keys are lower-case aliases; update as needed.
+# ---------------------------------------------------------------------------
+_HUGONIOT_S: dict[str, float] = {
+    # Copper
+    "cu": 1.49, "copper": 1.49,
+    # Aluminium
+    "al": 1.34, "aluminum": 1.34, "aluminium": 1.34,
+    # Zinc
+    "zn": 1.30, "zinc": 1.30,
+    # Brass (70Cu–30Zn typical)
+    "brass": 1.43,
+    # Titanium (CP-Ti / Grade 2)
+    "ti": 1.02, "cp-ti": 1.02, "ti_grade2": 1.02, "ti grade2": 1.02,
+    # Ti-6Al-4V
+    "ti64": 1.05, "ti-6al-4v": 1.05, "ti6al4v": 1.05,
+    # Vanadium
+    "v": 1.22, "vanadium": 1.22,
+    # Magnesium
+    "mg": 1.54, "magnesium": 1.54,
+}
+
+_DEFAULT_S = 1.49  # fall back to Cu value when material not recognised
+
+
+def get_hugoniot_S(material: str, default: float = _DEFAULT_S) -> float:
+    """Return the Hugoniot slope parameter *S* for *material*.
+
+    Parameters
+    ----------
+    material:
+        Material name or abbreviation (case-insensitive).
+    default:
+        Value to return when the material is not in the built-in table.
+
+    Returns
+    -------
+    float
+        Hugoniot *S* parameter (dimensionless).
+    """
+    return _HUGONIOT_S.get(str(material).lower().strip(), default)
+
+
+# ---------------------------------------------------------------------------
+# Core stress calculations
+# ---------------------------------------------------------------------------
+
+def shock_stress_acoustic(density: float, C0: float, peak_velocity: float) -> float:
+    """Acoustic approximation for peak shock stress.
+
+    Parameters
+    ----------
+    density:
+        Initial material density  [kg/m³].
+    C0:
+        Bulk wave speed  [m/s].
+    peak_velocity:
+        Free-surface velocity at peak  [m/s].
+
+    Returns
+    -------
+    float
+        Shock stress  [Pa].
+
+    Notes
+    -----
+    σ = 0.5 · ρ · C₀ · v_peak
+    This is the formula used in the original ALPSS code.
+    """
+    return 0.5 * density * C0 * float(peak_velocity)
+
+
+def shock_stress_hugoniot(
+    density: float,
+    C0: float,
+    peak_velocity: float,
+    S: float = _DEFAULT_S,
+) -> float:
+    """Hugoniot EOS peak shock stress.
+
+    Parameters
+    ----------
+    density:
+        Initial material density  [kg/m³].
+    C0:
+        Bulk wave speed  [m/s].
+    peak_velocity:
+        Free-surface velocity at peak  [m/s].
+    S:
+        Hugoniot slope parameter (dimensionless).  Defaults to 1.49 (Cu).
+
+    Returns
+    -------
+    float
+        Shock stress  [Pa].
+
+    Notes
+    -----
+    u_p     = v_fs / 2         (particle velocity)
+    U_shock = C₀ + S·u_p      (shock velocity)
+    σ       = ρ · U_shock · u_p
+    """
+    u_p = float(peak_velocity) / 2.0
+    U_s = C0 + S * u_p
+    return density * U_s * u_p
+
+
+def shock_stress_hugoniot_uncertainty(
+    density: float,
+    C0: float,
+    peak_velocity: float,
+    peak_velocity_unc: float,
+    S: float = _DEFAULT_S,
+) -> float:
+    """Propagated uncertainty for the Hugoniot shock stress.
+
+    Uses first-order error propagation through
+    ``σ = ρ · (C₀ + S·u_p) · u_p``  w.r.t. *u_p*.
+
+    Parameters
+    ----------
+    density:
+        Initial material density  [kg/m³].
+    C0:
+        Bulk wave speed  [m/s].
+    peak_velocity:
+        Free-surface velocity at peak  [m/s].
+    peak_velocity_unc:
+        1-σ uncertainty on *peak_velocity*  [m/s].
+    S:
+        Hugoniot slope parameter (dimensionless).
+
+    Returns
+    -------
+    float
+        1-σ shock stress uncertainty  [Pa].
+
+    Notes
+    -----
+    δσ/δu_p = ρ · (C₀ + 2·S·u_p)
+    δσ      = ρ · (C₀ + 2·S·u_p) · δu_p
+    """
+    u_p = float(peak_velocity) / 2.0
+    u_p_unc = float(peak_velocity_unc) / 2.0
+    return density * (C0 + 2.0 * S * u_p) * u_p_unc
+
+
+def calculate_shock_stress(
+    density: float,
+    C0: float,
+    peak_velocity: float,
+    peak_velocity_unc: float = 0.0,
+    material: str = "",
+    S: float | None = None,
+    method: str = "hugoniot",
+) -> dict[str, float]:
+    """Compute peak shock stress and its uncertainty.
+
+    This is the primary entry point used by ``alpss_main`` and ``saving``.
+
+    Parameters
+    ----------
+    density:
+        Initial material density  [kg/m³].
+    C0:
+        Bulk wave speed  [m/s].
+    peak_velocity:
+        Free-surface velocity at peak  [m/s].
+    peak_velocity_unc:
+        1-σ uncertainty on *peak_velocity*  [m/s].
+    material:
+        Material name (used to look up *S* when *S* is ``None``).
+    S:
+        Hugoniot slope parameter.  If ``None`` the value is looked up from
+        *material*; if the material is unknown the Cu default (1.49) is used.
+    method:
+        ``"hugoniot"`` (default) uses the EOS formula; ``"acoustic"`` uses
+        the simple approximation.
+
+    Returns
+    -------
+    dict with keys
+        * ``"shock_stress_pa"``     – stress in Pa
+        * ``"shock_stress_gpa"``    – stress in GPa
+        * ``"shock_stress_unc_pa"`` – 1-σ uncertainty in Pa
+        * ``"shock_stress_unc_gpa"``– 1-σ uncertainty in GPa
+        * ``"method"``              – which formula was used
+        * ``"S"``                   – Hugoniot *S* value used (nan for acoustic)
+    """
+    if S is None:
+        S_val = get_hugoniot_S(material) if material else _DEFAULT_S
+    else:
+        S_val = float(S)
+
+    if method == "acoustic":
+        stress_pa = shock_stress_acoustic(density, C0, peak_velocity)
+        unc_pa = shock_stress_acoustic(density, C0, peak_velocity_unc) if peak_velocity_unc else 0.0
+        S_used = np.nan
+    else:
+        stress_pa = shock_stress_hugoniot(density, C0, peak_velocity, S_val)
+        unc_pa = shock_stress_hugoniot_uncertainty(density, C0, peak_velocity, peak_velocity_unc, S_val)
+        S_used = S_val
+
+    return {
+        "shock_stress_pa": stress_pa,
+        "shock_stress_gpa": stress_pa * 1e-9,
+        "shock_stress_unc_pa": unc_pa,
+        "shock_stress_unc_gpa": unc_pa * 1e-9,
+        "method": method,
+        "S": S_used,
+    }

--- a/src/alpss/io/saving.py
+++ b/src/alpss/io/saving.py
@@ -24,6 +24,8 @@ def save(
     spall_ok=True,
     uncertainty_ok=True,
     error_msg=None,
+    spall_result=None,   # SpallResult from spall_analysis_with_dns (optional)
+    shock_result=None,   # dict from calculate_shock_stress (optional)
     **inputs,
 ):
     filename = os.path.splitext(os.path.basename(inputs["filepath"]))[0]
@@ -72,6 +74,20 @@ def save(
         )
         smooth_velocity_assets.append(smooth_velocity_path)
 
+    # save smoothed velocity with uncertainty — 4-column file read by SPADE
+    # columns: Time_s, Velocity_Smooth_m_s, Velocity_Uncertainty_m_s,
+    #          Velocity_Plus_Uncertainty_m_s
+    vel_plus_unc = vc_out["velocity_f_smooth"] + iua_out["vel_uncert"]
+    vel_smooth_uncert_data = np.stack(
+        (vc_out["time_f"], vc_out["velocity_f_smooth"], iua_out["vel_uncert"], vel_plus_unc),
+        axis=1,
+    )
+    vel_smooth_uncert_assets = [vel_smooth_uncert_data]
+    if inputs["save_data"]:
+        vel_smooth_uncert_path = f"{fname}-vel-smooth-with-uncert.csv"
+        np.savetxt(vel_smooth_uncert_path, vel_smooth_uncert_data, delimiter=",")
+        vel_smooth_uncert_assets.append(vel_smooth_uncert_path)
+
     # save the filtered voltage data
     voltage_data = np.stack(
         (
@@ -107,12 +123,48 @@ def save(
         )
         vel_uncert_assets.append(vel_uncert_path)
 
+    # Shock stress: prefer Hugoniot result passed from alpss_main; fall back to
+    # acoustic approximation for backward-compatibility when shock_result is None.
+    if shock_result is not None:
+        peak_shock_stress_gpa = shock_result.get("shock_stress_gpa", np.nan)
+        peak_shock_stress_unc_gpa = shock_result.get("shock_stress_unc_gpa", np.nan)
+        shock_method = shock_result.get("method", "hugoniot")
+        hugoniot_S = shock_result.get("S", np.nan)
+    else:
+        # Legacy acoustic approximation (Pa → GPa)
+        v_peak = sa_out["v_max_comp"]
+        peak_shock_stress_gpa = (
+            0.5 * inputs["density"] * inputs["C0"] * v_peak * 1e-9
+            if not np.isnan(v_peak) else np.nan
+        )
+        peak_shock_stress_unc_gpa = np.nan
+        shock_method = "acoustic_legacy"
+        hugoniot_S = np.nan
+
+    # DNS / spall classification from extended spall_analysis_with_dns
+    dns_classification = "Unknown"
+    spall_strength_gpa = np.nan
+    spall_strength_unc_gpa = np.nan
+    if spall_result is not None:
+        dns_classification = getattr(spall_result, "dns_classification", "Unknown")
+        raw_strength = getattr(spall_result, "spall_strength_pa", np.nan)
+        raw_unc = getattr(spall_result, "spall_strength_unc_pa", np.nan)
+        spall_strength_gpa = raw_strength * 1e-9 if not np.isnan(raw_strength) else np.nan
+        spall_strength_unc_gpa = raw_unc * 1e-9 if not np.isnan(raw_unc) else np.nan
+    else:
+        # Derive from legacy sa_out (Pa → GPa)
+        raw_strength = sa_out["spall_strength_est"]
+        spall_strength_gpa = raw_strength * 1e-9 if not np.isnan(raw_strength) else np.nan
+        spall_unc_pa = fua_out["spall_uncert"]
+        spall_strength_unc_gpa = spall_unc_pa * 1e-9 if not np.isnan(spall_unc_pa) else np.nan
+
     results_to_save = {
         "Date": start_time.strftime("%b %d %Y"),
         "Time": start_time.strftime("%I:%M %p"),
         "File Name": os.path.basename(inputs["filepath"]),
         "Velocity OK": True,
         "Spall OK": spall_ok,
+        "DNS Classification": dns_classification,
         "Uncertainty OK": uncertainty_ok,
         "Error Message": error_msg,
         "Run Time": (end_time - start_time),
@@ -123,10 +175,20 @@ def save(
         "Velocity at Recompression": sa_out["v_rc"],
         "Time at Recompression": sa_out["t_rc"],
         "Carrier Frequency": cen,
+        # Spall strength in GPa (converted from Pa using 0.5·ρ·C0·Δv·1e-9)
+        "Spall Strength (GPa)": spall_strength_gpa,
+        "Spall Strength Uncertainty (GPa)": spall_strength_unc_gpa,
+        # Legacy Pa fields kept for backward-compatibility
         "Spall Strength": sa_out["spall_strength_est"],
         "Spall Strength Uncertainty": fua_out["spall_uncert"],
         "Strain Rate": sa_out["strain_rate_est"],
         "Strain Rate Uncertainty": fua_out["strain_rate_uncert"],
+        # Shock stress (Hugoniot EOS: σ = ρ·U_s·u_p; GPa)
+        "Peak Shock Stress (GPa)": peak_shock_stress_gpa,
+        "Peak Shock Stress Uncertainty (GPa)": peak_shock_stress_unc_gpa,
+        "Shock Stress Method": shock_method,
+        "Hugoniot S": hugoniot_S,
+        # Legacy Pa field kept for backward-compatibility
         "Peak Shock Stress": (
             0.5 * inputs["density"] * inputs["C0"] * sa_out["v_max_comp"]
         ),
@@ -190,6 +252,7 @@ def save(
         "inputs": inputs_assets,
         "velocity": velocity_assets,
         "smooth_velocity": smooth_velocity_assets,
+        "vel_smooth_with_uncert": vel_smooth_uncert_assets,
         "voltage": voltage_assets,
         "noise": noise_assets,
         "vel_uncert": vel_uncert_assets,

--- a/tests/test_shock_stress.py
+++ b/tests/test_shock_stress.py
@@ -1,0 +1,105 @@
+import pytest
+import numpy as np
+
+from alpss.analysis.shock_stress import (
+    shock_stress_acoustic,
+    shock_stress_hugoniot,
+    shock_stress_hugoniot_uncertainty,
+    get_hugoniot_S,
+    calculate_shock_stress,
+)
+
+
+class TestGetHugonotS:
+    def test_copper(self):
+        assert get_hugoniot_S("Cu") == pytest.approx(1.49)
+
+    def test_copper_aliases(self):
+        for alias in ("cu", "Cu", "copper", "COPPER"):
+            assert get_hugoniot_S(alias) == pytest.approx(1.49)
+
+    def test_aluminum(self):
+        assert get_hugoniot_S("Al") == pytest.approx(1.34)
+
+    def test_unknown_material_returns_default(self):
+        assert get_hugoniot_S("unobtainium") == pytest.approx(1.49)
+
+    def test_custom_default(self):
+        assert get_hugoniot_S("mystery", default=1.0) == pytest.approx(1.0)
+
+
+class TestShockStressAcoustic:
+    def test_basic(self):
+        sigma = shock_stress_acoustic(density=8960, C0=3950, peak_velocity=300.0)
+        assert sigma == pytest.approx(0.5 * 8960 * 3950 * 300)
+
+    def test_zero_velocity(self):
+        assert shock_stress_acoustic(8960, 3950, 0.0) == pytest.approx(0.0)
+
+
+class TestShockStressHugoniot:
+    def test_copper_300ms(self):
+        rho, C0, S, v = 8960, 3950, 1.49, 300.0
+        u_p = v / 2
+        U_s = C0 + S * u_p
+        expected = rho * U_s * u_p
+        assert shock_stress_hugoniot(rho, C0, v, S) == pytest.approx(expected)
+
+    def test_larger_than_acoustic_for_positive_S(self):
+        rho, C0, S, v = 8960, 3950, 1.49, 200.0
+        assert shock_stress_hugoniot(rho, C0, v, S) > shock_stress_acoustic(rho, C0, v)
+
+    def test_equals_acoustic_when_S_zero(self):
+        rho, C0, v = 8960, 3950, 200.0
+        assert shock_stress_hugoniot(rho, C0, v, S=0.0) == pytest.approx(
+            shock_stress_acoustic(rho, C0, v)
+        )
+
+    def test_gpa_value_copper(self):
+        sigma_pa = shock_stress_hugoniot(8960, 3950, 300.0, 1.49)
+        sigma_gpa = sigma_pa * 1e-9
+        assert 1.0 < sigma_gpa < 10.0
+
+
+class TestShockStressUncertainty:
+    def test_positive_for_positive_unc(self):
+        unc = shock_stress_hugoniot_uncertainty(8960, 3950, 300.0, 10.0, 1.49)
+        assert unc > 0
+
+    def test_scales_linearly_with_velocity_unc(self):
+        unc1 = shock_stress_hugoniot_uncertainty(8960, 3950, 300.0, 10.0, 1.49)
+        unc2 = shock_stress_hugoniot_uncertainty(8960, 3950, 300.0, 20.0, 1.49)
+        assert unc2 == pytest.approx(2 * unc1, rel=1e-9)
+
+    def test_zero_unc_gives_zero(self):
+        assert shock_stress_hugoniot_uncertainty(8960, 3950, 300.0, 0.0, 1.49) == pytest.approx(0.0)
+
+
+class TestCalculateShockStress:
+    def test_hugoniot_method(self):
+        r = calculate_shock_stress(8960, 3950, 300.0, method="hugoniot")
+        assert r["method"] == "hugoniot"
+        assert r["shock_stress_gpa"] == pytest.approx(r["shock_stress_pa"] * 1e-9)
+        assert r["shock_stress_gpa"] > 0
+
+    def test_acoustic_method(self):
+        r = calculate_shock_stress(8960, 3950, 300.0, method="acoustic")
+        assert r["method"] == "acoustic"
+        assert np.isnan(r["S"])
+
+    def test_material_lookup(self):
+        r_cu = calculate_shock_stress(8960, 3950, 300.0, material="Cu")
+        assert r_cu["S"] == pytest.approx(1.49)
+
+    def test_explicit_S_overrides_material(self):
+        r = calculate_shock_stress(8960, 3950, 300.0, material="Cu", S=1.0)
+        assert r["S"] == pytest.approx(1.0)
+
+    def test_uncertainty_propagated(self):
+        r = calculate_shock_stress(8960, 3950, 300.0, peak_velocity_unc=10.0)
+        assert r["shock_stress_unc_gpa"] > 0
+
+    def test_gpa_pa_consistency(self):
+        r = calculate_shock_stress(8960, 3950, 300.0, peak_velocity_unc=5.0)
+        assert r["shock_stress_pa"] == pytest.approx(r["shock_stress_gpa"] * 1e9)
+        assert r["shock_stress_unc_pa"] == pytest.approx(r["shock_stress_unc_gpa"] * 1e9)


### PR DESCRIPTION
Adds `shock_stress.py` with Hugoniot EOS (`σ = ρ·(C₀+S·u_p)·u_p`) and acoustic approximation, first-order uncertainty propagation, and per-material S parameter lookup. Wired into `alpss_main` as Phase 2c. `save()` outputs `Peak Shock Stress (GPa)`, uncertainty, method, S, and a 4-column smoothed velocity CSV for SPADE/HELIX. Stacked on #28.