### PR TITLE
convert save_data and display_plots to booleans

### DIFF
--- a/src/alpss/alpss_main.py
+++ b/src/alpss/alpss_main.py
@@ -157,7 +157,7 @@ def alpss_main(**inputs):
                 angle_threshold_deg=inputs["hel_angle_threshold_deg"],
                 sample_name=os.path.basename(inputs.get("filepath", "")),
             )
-            if inputs.get("display_plots") != "yes":
+            if not inputs.get("display_plots"):
                 import matplotlib.pyplot as _plt
 
                 _plt.close(hel_fig)

--- a/src/alpss/alpss_run.py
+++ b/src/alpss/alpss_run.py
@@ -73,7 +73,7 @@ import os
 
 alpss_main(
     filename="example_file.csv",
-    save_data="yes",
+    save_data=True,
     start_time_user="none",
     header_lines=0,
     time_to_skip=0e-6,
@@ -117,7 +117,7 @@ alpss_main(
     out_files_dir="/srv/hemi01-j01/ALPSS/tests/output_data2",
     # exp_data_dir="/Users/Administrator/Desktop/PDV_DATA",
     # out_files_dir="/Users/Administrator/Desktop/ALPSS_output/custom",
-    display_plots="yes",
+    display_plots=True,
     plot_figsize=(30, 10),
     plot_dpi=300,
 )

--- a/src/alpss/plotting/plots.py
+++ b/src/alpss/plotting/plots.py
@@ -413,7 +413,7 @@ def plot_results(
     plt.tight_layout()
 
     # display the plots if desired. if this is turned off the plots will still save
-    if inputs["display_plots"] == "yes":
+    if inputs["display_plots"]:
         plt.show()
 
     return fig
@@ -456,14 +456,14 @@ def plot_voltage(data, **inputs):
     fig.suptitle("ERROR: Program Failed", c="r", fontsize=16)
 
     plt.tight_layout()
-    if inputs["save_data"] == "yes":
+    if inputs["save_data"]:
         fname = os.path.join(
             inputs["out_files_dir"],
             os.path.splitext(os.path.basename(inputs["filepath"]))[0],
         )
         dest = f"{fname}--error_plot.png"
         fig.savefig(dest)
-    if inputs["display_plots"] == "yes":
+    if inputs["display_plots"]:
         plt.show()
 
-    return fig, {"error": [mag, dest if inputs["save_data"] == "yes" else None]}
+    return fig, {"error": [mag, dest if inputs["save_data"] else None]}

--- a/src/alpss/validation.py
+++ b/src/alpss/validation.py
@@ -94,6 +94,10 @@ def validate_inputs(inputs):
     if unknown:
         raise ValueError(f"Unknown config params: {unknown}")
 
+    for bool_key in ("save_data", "display_plots"):
+        if not isinstance(inputs[bool_key], bool):
+            raise ValueError(f"'{bool_key}' must be a bool, got {type(inputs[bool_key]).__name__!r}.")
+
     stu = inputs["start_time_user"]
     if not (isinstance(stu, (int, float)) or stu in _START_TIME_MODES):
         raise ValueError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,8 +23,8 @@ def valid_inputs():
             "header_lines": 1,
             "time_to_skip": 2.3e-06,
             "time_to_take": 1.5e-06,
-            "save_data": "yes",
-            "display_plots": "no",
+            "save_data": True,
+            "display_plots": False,
         },
         "stft": {
             "sample_rate": 80000000000.0,

--- a/tests/input_data/config.json
+++ b/tests/input_data/config.json
@@ -5,8 +5,8 @@
         "header_lines": 1,
         "time_to_skip": 2.3e-06,
         "time_to_take": 1.5e-06,
-        "save_data": "yes",
-        "display_plots": "no"
+        "save_data": true,
+        "display_plots": false
     },
     "stft": {
         "sample_rate": 80000000000,

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -9,7 +9,7 @@ from alpss.commands import load_json_config
 
 def test_flatten_merges_sections():
     config = {
-        "io": {"filepath": "a.csv", "save_data": "yes"},
+        "io": {"filepath": "a.csv", "save_data": True},
         "material": {"density": 8960, "C0": 3950},
     }
     flat = _flatten_config(config)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -214,3 +214,21 @@ def test_invalid_carrier_filter_type_raises(flat_inputs):
     inputs["carrier_filter_type"] = "bad_filter"
     with pytest.raises(ValueError, match="Invalid carrier_filter_type"):
         validate_inputs(inputs)
+
+
+# --- bool params ---
+
+
+@pytest.mark.parametrize("key", ["save_data", "display_plots"])
+def test_bool_param_string_raises(flat_inputs, key):
+    inputs = copy.deepcopy(flat_inputs)
+    inputs[key] = "yes"
+    with pytest.raises(ValueError, match=f"'{key}' must be a bool"):
+        validate_inputs(inputs)
+
+
+@pytest.mark.parametrize("key,value", [("save_data", True), ("save_data", False), ("display_plots", True), ("display_plots", False)])
+def test_bool_param_valid(flat_inputs, key, value):
+    inputs = copy.deepcopy(flat_inputs)
+    inputs[key] = value
+    validate_inputs(inputs)


### PR DESCRIPTION
Closes #37

## Summary

- `save_data` and `display_plots` are now `bool` instead of `"yes"`/`"no"` strings
- `validate_inputs` raises if either param is not a `bool`
- All comparison sites updated (`== "yes"` → direct truthiness)
- Config files and fixtures updated (`"yes"` → `true`, `"no"` → `false`)

## Test plan

- `test_bool_param_string_raises` — passing `"yes"` raises `ValueError`
- `test_bool_param_valid` — `True`/`False` pass for both params