### PR TITLE
Fix HEL to use C_L instead of C0

### DIFF
--- a/src/alpss/analysis/hel.py
+++ b/src/alpss/analysis/hel.py
@@ -69,7 +69,6 @@ def hel_detection(
     min_points=3,
     min_velocity=10.0,
     density=None,
-    acoustic_velocity=None,
     C_L=None,
 ):
     """
@@ -100,11 +99,8 @@ def hel_detection(
         Minimum HEL velocity (m/s) to accept the detection. Default 10.0.
     density : float or None
         Material density in kg/m³. Required for HEL stress calculation.
-    acoustic_velocity : float or None
-        Bulk wave speed in m/s. Required for HEL stress calculation.
     C_L : float or None
-        Longitudinal wave velocity in m/s. Used for strain rate.
-        Falls back to acoustic_velocity if not provided.
+        Longitudinal wave velocity in m/s. Required for HEL stress and strain rate calculations.
 
     Returns
     -------
@@ -227,14 +223,12 @@ def hel_detection(
     # Compute HEL stress if material properties are provided
     strength_gpa = np.nan
     uncertainty_gpa = np.nan
-    if density is not None and acoustic_velocity is not None:
-        strength_gpa = 0.5 * density * acoustic_velocity * abs(fsv) / 1e9
-        uncertainty_gpa = 0.5 * density * acoustic_velocity * u_unc / 1e9
+    if density is not None and C_L is not None:
+        strength_gpa = 0.5 * density * C_L * abs(fsv) / 1e9
+        uncertainty_gpa = 0.5 * density * C_L * u_unc / 1e9
 
     # Compute strain rate if C_L is available
     strain_rate = np.nan
-    if C_L is None:
-        C_L = acoustic_velocity
     if C_L is not None:
         # Use the point just before the segment as reference, or the first
         # window point if the segment starts at index 0

--- a/src/alpss/utils/phases.py
+++ b/src/alpss/utils/phases.py
@@ -137,7 +137,6 @@ def run_hel_phase(vc_out, iua_out, **inputs) -> tuple:
                 min_points=inputs.get("hel_detection_min_points"),
                 min_velocity=inputs.get("minimum_HEL_velocity_expected"),
                 density=inputs.get("density"),
-                acoustic_velocity=inputs.get("C0"),
                 C_L=inputs.get("C_L"),
             )
             if hel_out.ok:

--- a/src/alpss/utils/validation.py
+++ b/src/alpss/utils/validation.py
@@ -42,7 +42,7 @@ _ALWAYS_REQUIRED = [
 ]
 
 # Optional keys — warning is emitted if absent.
-_OPTIONAL = ["C_L", "bytestring"]
+_OPTIONAL = ["bytestring"]
 
 _REQUIRED_BY_MODE = {
     "start_time_user=otsu": [],
@@ -51,7 +51,7 @@ _REQUIRED_BY_MODE = {
     "carrier_filter_type=gaussian_notch": ["order", "wid"],
     "carrier_filter_type=sin_fit_subtract": ["wid", "t_fit_begin", "t_fit_end"],
     "spall_calculation=True": ["pb_neighbors", "pb_idx_correction", "rc_neighbors", "rc_idx_correction", "C0", "density", "delta_rho", "delta_C0", "delta_lam", "delta_theta"],
-    "hel_calculation=True": ["hel_start_time_ns", "hel_end_time_ns", "hel_angle_threshold_deg", "hel_detection_min_points", "minimum_HEL_velocity_expected", "C0", "density"],
+    "hel_calculation=True": ["hel_start_time_ns", "hel_end_time_ns", "hel_angle_threshold_deg", "hel_detection_min_points", "minimum_HEL_velocity_expected", "density", "C_L"],
 }
 
 _ALL_KNOWN = (

--- a/tests/input_data/config.json
+++ b/tests/input_data/config.json
@@ -48,6 +48,7 @@
     },
     "material": {
         "C0": 4540,
+        "C_L": 4540,
         "density": 1730,
         "delta_rho": 9,
         "delta_C0": 23,

--- a/tests/test_hel.py
+++ b/tests/test_hel.py
@@ -69,7 +69,7 @@ class TestHELDetection:
             min_points=5,
             min_velocity=50.0,
             density=8960,
-            acoustic_velocity=3940,
+            C_L=3940,
         )
         assert result.ok is True
         assert result.strength_gpa > 0
@@ -105,10 +105,10 @@ class TestHELDetection:
             hel_detection(t, v, u)
 
     def test_hel_stress_calculation(self, synthetic_hel_signal):
-        """Verify HEL stress = 0.5 * density * acoustic_velocity * fsv / 1e9."""
+        """Verify HEL stress = 0.5 * density * C_L * fsv / 1e9."""
         t, v, u = synthetic_hel_signal
         density = 8960
-        acoustic_velocity = 3940
+        C_L = 3940
         result = hel_detection(
             t,
             v,
@@ -118,10 +118,10 @@ class TestHELDetection:
             min_points=5,
             min_velocity=50.0,
             density=density,
-            acoustic_velocity=acoustic_velocity,
+            C_L=C_L,
         )
         expected_gpa = (
-            0.5 * density * acoustic_velocity * abs(result.free_surface_velocity) / 1e9
+            0.5 * density * C_L * abs(result.free_surface_velocity) / 1e9
         )
         assert result.strength_gpa == pytest.approx(expected_gpa, rel=1e-6)
 
@@ -138,7 +138,6 @@ class TestHELDetection:
             min_points=5,
             min_velocity=50.0,
             density=8960,
-            acoustic_velocity=3940,
             C_L=5000,
         )
         assert result.ok is True

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -132,7 +132,7 @@ def test_spall_calculation_false_does_not_require_params(flat_inputs):
 # --- _REQUIRED_BY_MODE: hel_calculation ---
 
 
-@pytest.mark.parametrize("missing_key", ["hel_start_time_ns", "hel_end_time_ns", "hel_angle_threshold_deg", "hel_detection_min_points", "minimum_HEL_velocity_expected", "C0", "density"])
+@pytest.mark.parametrize("missing_key", ["hel_start_time_ns", "hel_end_time_ns", "hel_angle_threshold_deg", "hel_detection_min_points", "minimum_HEL_velocity_expected", "C_L", "density"])
 def test_hel_calculation_requires_key(flat_inputs, missing_key):
     inputs = copy.deepcopy(flat_inputs)
     inputs["spall_calculation"] = False


### PR DESCRIPTION
Fixes #36

## Changes
- Remove acoustic_velocity parameter from hel_detection()
- Use C_L for both strength and strain rate calculations
- Remove fallback from C_L to acoustic_velocity
- Update phases.py to pass C_L instead of C0
- Make C_L conditionally required when hel_calculation=True