### PR TITLE
52 fix cusum start time detection implimentation

### DIFF
--- a/src/alpss/detection/spall_doi_finder.py
+++ b/src/alpss/detection/spall_doi_finder.py
@@ -3,7 +3,7 @@ import cv2 as cv
 from alpss.utils.stft import stft
 import logging
 from scipy import signal
-from scipy.fft import fft, fftfreq
+from scipy.fft import fft, fftshift, ifft 
 import matplotlib.pyplot as plt
 import os
 
@@ -128,31 +128,39 @@ def spall_doi_finder(data, **inputs):
 
             # Collect necessary parameters
             carrier_band_time = inputs["carrier_band_time"]
-            k = inputs["cusum_offset"]
-            h = inputs["cusum_threshold"]
+            k=inputs["cusum_offset"]
+            h=inputs["cusum_threshold"]
+            f_min = inputs["freq_min"]
+            f_max = inputs["freq_max"]
 
-            # Carrier band Frequency
-            carrier_mask = time < carrier_band_time
-            carrier_fft_vals = fft(voltage[carrier_mask])
-            carrier_fft_freqs = fftfreq(voltage[carrier_mask].size, 1 / fs)
-            mask3 = carrier_fft_freqs > 0
-            max_idx = np.argmax(np.abs(carrier_fft_vals * mask3))
-            cen = carrier_fft_freqs[max_idx]
-            idx = np.argmin(np.abs(f - cen))
-            signal = mag[idx, :]
-            mask4 = t < carrier_band_time
-            mask5 = t > (t.max() - carrier_band_time)
-            mu0 = np.mean(signal[mask4])
-            mu1 = 0  # Expected post-change signal level
-            sigma0 = np.var(signal[mask4])
+            # Apply a bandpass filter to get rid of noise outside of frequency bounds
+            numpts = len(time)
+            pad_len = numpts // 2
+            voltage_padded = np.pad(voltage, (pad_len, pad_len), mode='reflect')
+            numpts_padded = len(voltage_padded)
+            freq_padded = fftshift(np.arange((-numpts_padded / 2), (numpts_padded / 2)) * fs / numpts_padded)
+            filt_padded = (freq_padded > f_min) * (freq_padded < f_max)
+            voltage_filt_padded = ifft(fft(voltage_padded) * filt_padded)
+            voltage_filt = voltage_filt_padded[pad_len:pad_len + numpts]
 
-            print("signal shape: ", signal.shape)
-            detection_indices, change_indices, G, s = cusum(
-                signal, mu0, mu1, sigma0, h, k
-            )
+            # Unwrap the phase
+            phas = np.unwrap(np.angle(voltage_filt), axis=0)
 
-            print("change _indices shape: ", change_indices.shape)
-            detection_time = t[change_indices]
+            # Analyzed signal is equal to the gradient of the phase. Essentially a pseudo-velocity
+            signal = np.gradient(phas)
+
+            # Skip leading edge samples to avoid filter artifact spikes
+            edge_skip = 100
+            signal_eval = signal[edge_skip:]
+            time_eval = time[edge_skip:]
+
+            # Initial mean and standard deviation of the signal. Utilized in cusum
+            mask = time_eval < carrier_band_time
+            mu0 = np.mean(signal_eval[mask])
+            sigma0 = np.var(signal_eval[mask])
+
+            detection_indices, change_indices, G, s = cusum(signal_eval, mu0, sigma0, h, k)
+            detection_time = time_eval[change_indices]
 
             # these params become nan because they are only needed if the program
             # is finding the signal start time automatically
@@ -163,9 +171,7 @@ def spall_doi_finder(data, **inputs):
             # use the user input signal start time to define the domain of interest
             t_start_detected = detection_time
         else:
-            raise TypeError(
-                f"invalid mode assigned to variable 'start_time_user': {inputs.get('start_time_user')}"
-            )
+            raise TypeError(f"invalid mode assigned to variable 'start_time_user': {inputs.get('start_time_user')}")
 
     # if using a user input for the signal start time
     else:
@@ -218,22 +224,21 @@ def spall_doi_finder(data, **inputs):
     return sdf_out
 
 
-def cusum(signal, mu0, mu1, sigma, h, k):
+def cusum(signal, mu0, sigma, h, k):
     """
-    Detect a single mean shift from mu0 to mu1 using CUSUM.
+    Detect a single mean shift from mu0 using CUSUM.
     Returns:
     - Detection index
     - Estimated change point index
     - Full G[k] array
     """
     # Score for general mean change
-    Z = (signal - mu0) / (np.sqrt(sigma))
-    s = -Z - k
-    # s = ((mu1 - mu0) / sigma) * (signal - mu0) - ((mu0**2 - mu1**2) / (2 * sigma))
+    Z = (signal - mu0)/(np.sqrt(sigma))
+    s = Z - k
     G = np.zeros_like(s)
 
     for k in range(1, len(s)):
-        G[k] = max(G[k - 1] + s[k], 0)
+        G[k] = max(G[k-1] + s[k], 0)
 
         if G[k] > h:
             detect_idx = k

--- a/src/alpss/detection/spall_doi_finder.py
+++ b/src/alpss/detection/spall_doi_finder.py
@@ -221,6 +221,10 @@ def spall_doi_finder(data, **inputs):
         sdf_out["phase"] = phase
         sdf_out["iq_fig"] = iq_fig
 
+    if inputs.get("start_time_user") == "cusum":
+        sdf_out["cusum_time"] = time_eval
+        sdf_out["cusum_s"] = s
+
     return sdf_out
 
 

--- a/src/alpss/plotting/plots.py
+++ b/src/alpss/plotting/plots.py
@@ -121,6 +121,7 @@ def plot_results(
         ax4.plot(sdf_out["cusum_time"]*1e9,sdf_out["cusum_s"])
         ax4.set_title("Cusum Detection")
         ax4.set_xlabel("Time (ns)")
+        ax4.set_ylim([-inputs["cusum_offset"]-1,100])
     else:
         ax4.imshow(
             sdf_out["th3"],
@@ -141,9 +142,9 @@ def plot_results(
         ax4.set_ylabel("Frequency (GHz)")
         ax4.minorticks_on()
         ax4.set_title("Thresholded Spectrogram")
-        ax4.set_xlim([sdf_out["t_doi_start"] / 1e-9, sdf_out["t_doi_end"] / 1e-9])
     if inputs["start_time_user"] == "otsu":
         ax4.axhline(sdf_out["f_doi"][sdf_out["f_doi_carr_top_idx"]] / 1e9, c="r")    
+    ax4.set_xlim([sdf_out["t_doi_start"] / 1e-9, sdf_out["t_doi_end"] / 1e-9])
     ax4.axvline(sdf_out["t_start_detected"] / 1e-9, ls="--", c="r")
     ax4.axvline(sdf_out["t_start_corrected"] / 1e-9, ls="-", c="r")
 

--- a/src/alpss/plotting/plots.py
+++ b/src/alpss/plotting/plots.py
@@ -117,29 +117,36 @@ def plot_results(
     ax3.set_title("Spectrogram Original Signal")
 
     #################### plotting the thresholded spectrogram on the ROI to show how the signal start time is found
-    ax4.imshow(
-        sdf_out["th3"],
-        aspect="auto",
-        origin="lower",
-        interpolation="none",
-        extent=[
-            sdf_out["t"][0] / 1e-9,
-            sdf_out["t"][-1] / 1e-9,
-            sdf_out["f_doi"][0] / 1e9,
-            sdf_out["f_doi"][-1] / 1e9,
-        ],
-        cmap=inputs["cmap"],
-    )
+    if inputs["start_time_user"] == "cusum":
+        ax4.plot(sdf_out["cusum_time"]*1e9,sdf_out["cusum_s"])
+        ax4.set_title("Cusum Detection")
+        ax4.set_xlabel("Time (ns)")
+    else:
+        ax4.imshow(
+            sdf_out["th3"],
+            aspect="auto",
+            origin="lower",
+            interpolation="none",
+            extent=[
+                sdf_out["t"][0] / 1e-9,
+                sdf_out["t"][-1] / 1e-9,
+                sdf_out["f_doi"][0] / 1e9,
+                sdf_out["f_doi"][-1] / 1e9,
+            ],
+            cmap=inputs["cmap"],
+        )
+        ax4.set_title("Thresholded Spectrogram")
+        ax4.set_ylim([inputs["freq_min"] / 1e9, inputs["freq_max"] / 1e9])
+        ax4.set_xlabel("Time (ns)")
+        ax4.set_ylabel("Frequency (GHz)")
+        ax4.minorticks_on()
+        ax4.set_title("Thresholded Spectrogram")
+        ax4.set_xlim([sdf_out["t_doi_start"] / 1e-9, sdf_out["t_doi_end"] / 1e-9])
+    if inputs["start_time_user"] == "otsu":
+        ax4.axhline(sdf_out["f_doi"][sdf_out["f_doi_carr_top_idx"]] / 1e9, c="r")    
     ax4.axvline(sdf_out["t_start_detected"] / 1e-9, ls="--", c="r")
     ax4.axvline(sdf_out["t_start_corrected"] / 1e-9, ls="-", c="r")
-    if inputs["start_time_user"] == "otsu":
-        ax4.axhline(sdf_out["f_doi"][sdf_out["f_doi_carr_top_idx"]] / 1e9, c="r")
-    ax4.set_ylim([inputs["freq_min"] / 1e9, inputs["freq_max"] / 1e9])
-    ax4.set_xlim([sdf_out["t_doi_start"] / 1e-9, sdf_out["t_doi_end"] / 1e-9])
-    ax4.set_xlabel("Time (ns)")
-    ax4.set_ylabel("Frequency (GHz)")
-    ax4.minorticks_on()
-    ax4.set_title("Thresholded Spectrogram")
+
 
     #################### plotting the spectrogram of the ROI with the start-time line to see how well it lines up
     plt5 = ax5.imshow(

--- a/tests/input_data/config.json
+++ b/tests/input_data/config.json
@@ -26,16 +26,16 @@
         "t_before": 5.0e-09,
         "t_after": 5.0e-08,
         "iq_threshold_factor": 0.4,
-        "cusum_offset": 5,
-        "cusum_threshold": 1000,
+        "cusum_offset": 2,
+        "cusum_threshold": 100,
         "carrier_band_time": 2.5e-07
     },
     "carrier": {
         "carrier_filter_type": "gaussian_notch",
         "order": 6,
         "wid": 50000000.0,
-        "t_fit_begin": 20,
-        "t_fit_end": 300
+        "t_fit_begin": 20e-9,
+        "t_fit_end": 300e-9
     },
     "velocity": {
         "smoothing_window": 601,
@@ -75,7 +75,7 @@
     },
     "plotting": {
         "cmap": "viridis",
-        "plot_figsize": [80, 40],
+        "plot_figsize": [30, 10],
         "plot_dpi": 300
     }
 }

--- a/tests/input_data/config.json
+++ b/tests/input_data/config.json
@@ -26,16 +26,16 @@
         "t_before": 5.0e-09,
         "t_after": 5.0e-08,
         "iq_threshold_factor": 0.4,
-        "cusum_offset": 5,
-        "cusum_threshold": 1000,
+        "cusum_offset": 2,
+        "cusum_threshold": 100,
         "carrier_band_time": 2.5e-07
     },
     "carrier": {
         "carrier_filter_type": "gaussian_notch",
         "order": 6,
-        "wid": 50000000.0,
-        "t_fit_begin": 20,
-        "t_fit_end": 300
+        "wid": 0.2e9,
+        "t_fit_begin": 20e-9,
+        "t_fit_end": 300e-9
     },
     "velocity": {
         "smoothing_window": 601,
@@ -75,7 +75,7 @@
     },
     "plotting": {
         "cmap": "viridis",
-        "plot_figsize": [80, 40],
+        "plot_figsize": [30, 10],
         "plot_dpi": 300
     }
 }

--- a/tests/test_alpss_repeatibility.py
+++ b/tests/test_alpss_repeatibility.py
@@ -74,7 +74,7 @@ def test_alpss_exact_values(valid_inputs, start_time_user, carrier_filter_type):
         ), f"Mismatch for '{key}': expected {val}, got {result_dict[key]}"
 
 
-@pytest.mark.parametrize("start_time_user", ["otsu", "iq", 7.5e-07])
+@pytest.mark.parametrize("start_time_user", ["otsu", "iq", "cusum", 7.5e-07])
 @pytest.mark.parametrize("carrier_filter_type", ["gaussian_notch", "none"])
 def test_alpss_smoke(valid_inputs, start_time_user, carrier_filter_type):
     """Smoke test: mode/filter combos complete without error and return valid results."""


### PR DESCRIPTION
- Update cusum implimentation to utilize the gradient of the phase. Includes bandpass filtering and end effect filtering
- Add cusum graph in overall plot overview that replaces "otsu" thresholded graph when "cusum" is selected. This graph is the start time detection graph now. In future "IQ" graph could go here
- Add cusum test to pytest alpss repeatability smoke test
- Update incorrect default value for "sin_fit_subtract" in test config