### PR TITLE
Make spall_uncertainty conditional on spall_ok

### DIFF
--- a/src/alpss/alpss_main.py
+++ b/src/alpss/alpss_main.py
@@ -51,7 +51,7 @@ def alpss_main(**inputs):
     # --- Phase 2b: Spall uncertainty analysis ---
     sua_out, spall_uncertainty_ok, spall_uncertainty_error = run_spall_uncertainty_phase(
         cen, vc_out, sa_out, iua_out, spall_ok, **inputs
-    ) if velocity_ok else (default_spall_uncertainty_output(), False, "spall_uncertainty: skipped due to velocity_ok=false")
+    ) if velocity_ok and spall_ok else (default_spall_uncertainty_output(), False, "spall_uncertainty: skipped due to velocity_ok=false" if not velocity_ok else "spall_uncertainty: skipped due to spall_ok=false")
     if spall_uncertainty_error:
         errors.append(spall_uncertainty_error)
 


### PR DESCRIPTION
Closes #60

spall_uncertainty analysis now only runs if both velocity_ok and spall_ok are true. Error messages clarify whether skipping was due to velocity or spall failure.